### PR TITLE
Add OPNsenseConfig uitility with tests

### DIFF
--- a/docs/docsite/rst/development_guide.rst
+++ b/docs/docsite/rst/development_guide.rst
@@ -75,6 +75,36 @@ The official Ansible Documentation (`Collection Structure
 <https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_structure.html#collection-structure>`__)
 provides further reference regarding collection structure guidelines.
 
+Using the OPNsense config XML in plugins
+----------------------------------------
+The `OPNsenseConfig` utility module provides a convenient way to interact with
+the OPNsense config file `/conf/config.xml` in Ansible plugins. It offers a
+context manager that simplifies accessing, modifying, and managing configuration
+values.
+
+When working with Ansible plugins that require reading or updating configuration
+settings in the OPNsense config file, the `OPNsenseConfig` utility can be used
+to streamline the process. It abstracts away the complexities of parsing and
+manipulating XML, allowing developers to focus on the specific configuration
+logic.
+
+Example
+~~~~~~~
+
+Here's an example of how to use the `OPNsenseConfig` utility:
+
+.. code-block:: python
+
+    from ansible_collections.puzzle.opnsense.plugins.module_utils import OPNsenseConfig
+
+    ...
+
+    with OPNsenseConfig() as config:
+        value = config["key"]  # Access a configuration value
+        config["key"] = new_value  # Modify a configuration value
+        del config["key"]  # Delete a configuration value
+        config.save()  # Save changes
+
 
 Testing Your Code
 =================

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -1,0 +1,99 @@
+# Copyright: (c) 2023, Puzzle ITC
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Utilities for interactions with the OPNsense config file /conf/config.xml"""
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+from typing import Any
+from xml.etree import ElementTree
+
+from ansible_collections.puzzle.opnsense.plugins.module_utils import xml_utils
+
+
+class OPNsenseConfig:
+    """
+    Utility context manager for interactions with the OPNsense config file /conf/config.xml.
+
+    Usage:
+       with OPNsenseConfig() as config:
+           # Access configuration values
+           value = config["key"]
+
+           # Modify configuration values
+           config["key"] = new_value
+
+           # Delete configuration values
+           del config["key"]
+
+           # Save changes
+           config.save()
+
+    Note:
+       - The context manager ensures that any changes made to the config are saved before exiting the block.
+    """
+    _config_path: str
+    _config_dict: dict
+
+    def __init__(self, path: str = "/conf/config.xml"):
+        """
+        Initializes an instance of OPNsenseConfig.
+
+        :param path:  The path to the OPNsense config file (default: "/conf/config.xml").
+        """
+        self._config_path = path
+        self._config_dict = self._parse_config_from_file()
+
+    def __enter__(self) -> "OPNsenseConfig":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Exits the context manager and checks if the config has changed and not saved.
+        :raises RuntimeError: If changes are present which have not been saved.
+        :return:
+        """
+        if self.changed:
+            raise RuntimeError("Config has changed. Cannot exit without saving.")
+
+    def __getitem__(self, key: Any) -> Any:
+        return self._config_dict[key]
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        self._config_dict[key] = value
+
+    def __delitem__(self, key: Any) -> None:
+        del self._config_dict[key]
+
+    def __contains__(self, key: Any) -> bool:
+        return key in self._config_dict
+
+    def _parse_config_from_file(self) -> dict:
+        _config_root: ElementTree = ElementTree.parse(self._config_path).getroot()
+        return xml_utils.etree_to_dict(_config_root)["opnsense"] or {}
+
+    def save(self) -> bool:
+        """
+        Saves the config dictionary to the config file if changes have been made.
+
+        :return: True if changes were saved, False if no changes were detected.
+        """
+        if self.changed:
+            new_config_root = xml_utils.dict_to_etree("opnsense", self._config_dict)[0]
+            new_tree = ElementTree.ElementTree(new_config_root)
+            new_tree.write(self._config_path, encoding='utf-8', xml_declaration=True)
+            self._config_dict = self._parse_config_from_file()
+            return True
+        return False
+
+    @property
+    def changed(self) -> bool:
+        """
+        Enters the context manager.
+
+        :return: True if changes have been made to the config, False otherwise.
+        """
+        orig_dict = self._parse_config_from_file()
+        return orig_dict != self._config_dict

--- a/tests/unit/plugins/module_utils/test_config_utils.py
+++ b/tests/unit/plugins/module_utils/test_config_utils.py
@@ -1,0 +1,155 @@
+# Copyright: (c) 2023, Puzzle ITC
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""Tests for the plugins.module_utils.config_utils module."""
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import os
+from tempfile import NamedTemporaryFile
+from xml.etree import ElementTree
+
+import pytest
+from ansible_collections.puzzle.opnsense.plugins.module_utils import xml_utils
+from ansible_collections.puzzle.opnsense.plugins.module_utils.config_utils import OPNsenseConfig
+
+
+@pytest.fixture(scope="module")
+def sample_config_path():
+    # Create a temporary file with sample config for testing
+    config_content = """<?xml version="1.0"?>
+<opnsense>
+    <test_key>test_value</test_key>
+</opnsense>"""
+    with NamedTemporaryFile(delete=False) as temp_file:
+        temp_file.write(config_content.encode())
+        temp_file.flush()
+        yield temp_file.name
+    os.unlink(temp_file.name)
+
+
+def test_get_item(sample_config_path):
+    """
+    Test retrieving a value from the config.
+
+    Given a sample OPNsense configuration file, the test verifies that a specific key-value pair
+    can be retrieved using the OPNsenseConfig object.
+
+    The expected behavior is that the retrieved value matches the original value in the config file.
+    """
+    with OPNsenseConfig(path=sample_config_path) as config:
+        assert config["test_key"] == "test_value"
+        assert not config.save()
+
+
+def test_set_item(sample_config_path):
+    """
+    Test setting a value in the config.
+
+    Given a sample OPNsense configuration file, the test verifies that a new key-value pair
+    can be added to the config using the OPNsenseConfig object.
+
+    The expected behavior is that the added key-value pair is present in the config
+    and the `save` method returns True indicating that the config has changed. When using
+    a new config context the changes are expected to persist.
+    """
+    with OPNsenseConfig(path=sample_config_path) as config:
+        config["new_key"] = "new_value"
+        assert config["new_key"] == "new_value"
+        assert config.save()
+
+    with OPNsenseConfig(path=sample_config_path) as new_config:
+        assert "new_key" in new_config
+        assert new_config["new_key"] == "new_value"
+
+
+def test_del_item(sample_config_path):
+    """
+    Test deleting a value from the config.
+
+    Given a sample OPNsense configuration file, the test verifies that a key-value pair
+    can be removed from the config using the `del` statement with the OPNsenseConfig object.
+
+    The expected behavior is that the deleted key is no longer present in the config,
+    the `changed` property is True indicating that the config has changed,
+    and the `save` method returns True indicating that the config has changed. When using
+    a new config context the changes are expected to persist.
+    """
+    with OPNsenseConfig(path=sample_config_path) as config:
+        del config["test_key"]
+        assert "test_key" not in config
+        assert config.changed
+        assert config.save()
+
+    with OPNsenseConfig(path=sample_config_path) as new_config:
+        assert "test_key" not in new_config
+
+
+def test_contains(sample_config_path):
+    """
+    Test checking if a key exists in the config.
+
+    Given a sample OPNsense configuration file, the test verifies that the existence of a key
+    in the config can be checked using the `in` statement with the OPNsenseConfig object.
+
+    The expected behavior is that the test_key is found in the config,
+    and a non-existent key is not found.
+    """
+    with OPNsenseConfig(path=sample_config_path) as config:
+        assert "test_key" in config
+        assert "nonexistent_key" not in config
+        assert not config.save()
+
+
+def test_save(sample_config_path):
+    """
+    Test saving changes to the config.
+
+    Given a sample OPNsense configuration file, the test verifies that changes made to the config
+    using the OPNsenseConfig object can be saved.
+
+    The expected behavior is that the `save` method returns True when the config has changed,
+    indicating that the changes were successfully saved.
+    """
+    with OPNsenseConfig(path=sample_config_path) as config:
+        config["test_key"] = "modified_value"
+        assert config.save()
+    # Reload the saved config and assert the changes were saved
+    reloaded_config = xml_utils.etree_to_dict(ElementTree.parse(sample_config_path).getroot())["opnsense"]
+    assert reloaded_config["test_key"] == "modified_value"
+
+    with OPNsenseConfig(path=sample_config_path) as new_config:
+        assert new_config["test_key"] == "modified_value"
+
+
+def test_changed(sample_config_path):
+    """
+    Test checking if the config has changed.
+
+    Given a sample OPNsense configuration file, the test verifies that the `changed` property
+    of the OPNsenseConfig object correctly indicates whether the config has changed.
+
+    The expected behavior is that the `changed` property is False initially, and True after making changes
+    to the config.
+    """
+    with OPNsenseConfig(path=sample_config_path) as config:
+        assert not config.changed
+        config["test_key"] = "modified_value"
+        assert config.changed
+        config.save()
+
+
+def test_exit_without_saving(sample_config_path):
+    """
+    Test exiting the context without saving changes.
+
+    Given a sample OPNsense configuration file, the test verifies that when changes are made to the config
+    using the OPNsenseConfig object, attempting to exit the context without saving the changes raises a RuntimeError.
+
+    The expected behavior is that a RuntimeError is raised with the message "Config has changed. Cannot exit without saving."
+    """
+    with pytest.raises(RuntimeError, match="Config has changed. Cannot exit without saving."):
+        with OPNsenseConfig(path=sample_config_path) as config:
+            config["test_key"] = "modified_value"
+            # The RuntimeError should be raised upon exiting the context without saving


### PR DESCRIPTION
In order to offer a easy way for future modules to manage the OPNsense `config.xml` this PR adds the `OPNsenseConfig` context manager. Usage of this utility for future modules is as follows:

```python3
with OPNsenseConfig() as config:
    # Access configuration values
    value = config["key"]

    # Modify configuration values
    config["key"] = new_value

    # Delete configuration values
    del config["key"]

    # Save changes
    config.save()
```

The idea is that config properties are accessible in a `dict` structure. Settings are accessible at the same positions as in the XML file under the root tag `opnsense`.

For example, firewall filter rules would look like this:

```xml
<opnsense>
    ...
    <filter>
        <rule>....</rule>
        <rule>....</rule>
        ...
    </filter>
</opnsense>
```
management of these rules using the `OPNsenseConfig`:
``` python3
with OPNsenseConfig() as config:
    config["filter"].append(some_new_rule)
    config.save()
```