### PR TITLE
improove OPNsenseConfig errorhandling

### DIFF
--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -55,6 +55,8 @@ class OPNsenseConfig:
         :raises RuntimeError: If changes are present which have not been saved.
         :return:
         """
+        if exc_type:
+            raise exc_type(f"Exception occurred: {exc_val}")
         if self.changed:
             raise RuntimeError("Config has changed. Cannot exit without saving.")
 


### PR DESCRIPTION
Currently, if an exception is occurring during a module execution within the context of a `OPNsenseConfig` object, python calls `__exit__` which results in a misleading error message `Config has changed. Cannot exit without saving.`.
If for example we try to update the config by modifying it but we did not specify `become: true` we get the following error message:

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: RuntimeError: Config has changed. Cannot exit without saving.
fatal: [opnsense]: FAILED! 
````

By first checking the exception type, we can make sure there was no exception and then proceed with the check for a changed config. If there was an exception, we will return it's type and value:

```
TASK [test] **************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: PermissionError: Exception occurred: [Errno 13] Permission denied: '/conf/config.xml'

