### PR TITLE
initial commit of the system_settings_general module

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,6 +4,7 @@ disable=
     import-error,
     no-name-in-module,
     wrong-import-position,
+    too-many-branches,
 
 [BASIC]
 

--- a/molecule/system_settings_general/converge.yml
+++ b/molecule/system_settings_general/converge.yml
@@ -1,0 +1,20 @@
+---
+- name: converge
+  hosts: all
+  become: true
+  tasks:
+    - name: Converge - Set hostname
+      puzzle.opnsense.system_settings_general:
+        hostname: opnsense01
+
+    - name: Converge - Set domain
+      puzzle.opnsense.system_settings_general:
+        domain: example.org
+
+    - name: get hostname
+      ansible.builtin.command: hostname
+      register: hostname_value
+      changed_when: false
+
+    - ansible.builtin.assert:
+        that: hostname_value.stdout == "opnsense01.example.org"

--- a/molecule/system_settings_general/converge.yml
+++ b/molecule/system_settings_general/converge.yml
@@ -11,10 +11,31 @@
       puzzle.opnsense.system_settings_general:
         domain: example.org
 
-    - name: get hostname
+    - name: Converge - Set timezone
+      puzzle.opnsense.system_settings_general:
+        timezone: Europe/Zurich
+
+    - name: Get hostname
       ansible.builtin.command: hostname
       register: hostname_value
       changed_when: false
 
-    - ansible.builtin.assert:
+    - name: Get current tz
+      ansible.builtin.stat:
+        path: /etc/localtime
+      register: current_tz_stat
+      changed_when: false
+
+    - name: Get desired tz
+      ansible.builtin.stat:
+        path: /usr/share/zoneinfo/Europe/Zurich
+      register: desired_tz_stat
+      changed_when: false
+
+    - name: Compare hostname
+      ansible.builtin.assert:
         that: hostname_value.stdout == "opnsense01.example.org"
+
+    - name: Compare tz
+      ansible.builtin.assert:
+        that: desired_tz_stat.stat.checksum == current_tz_stat.stat.checksum

--- a/molecule/system_settings_general/molecule.yml
+++ b/molecule/system_settings_general/molecule.yml
@@ -36,6 +36,16 @@ platforms:
           - 'vm.guest = :freebsd'
           - 'ssh.sudo_command = "%c"'
           - 'ssh.shell = "/bin/sh"'
+    - name: "23.7"
+      box: puzzle/opnsense
+      hostname: false
+      box_version: "23.7"
+      memory: 1024
+      cpus: 2
+      instance_raw_config_args:
+          - 'vm.guest = :freebsd'
+          - 'ssh.sudo_command = "%c"'
+          - 'ssh.shell = "/bin/sh"'
 
 provisioner:
     name: ansible

--- a/molecule/system_settings_general/molecule.yml
+++ b/molecule/system_settings_general/molecule.yml
@@ -1,0 +1,47 @@
+---
+scenario:
+    name: system_settings_general
+    test_sequence:
+        # - dependency not relevant uless we have requirements
+        - destroy
+        - syntax
+        - create
+        - converge
+        - idempotence
+        - verify
+        - destroy
+
+driver:
+    name: vagrant
+    parallel: true
+
+platforms:
+    - name: "22.7"
+      hostname: false
+      box: puzzle/opnsense
+      box_version: "22.7"
+      memory: 1024
+      cpus: 2
+      instance_raw_config_args:
+          - 'vm.guest = :freebsd'
+          - 'ssh.sudo_command = "%c"'
+          - 'ssh.shell = "/bin/sh"'
+    - name: "23.1"
+      box: puzzle/opnsense
+      hostname: false
+      box_version: "23.1"
+      memory: 1024
+      cpus: 2
+      instance_raw_config_args:
+          - 'vm.guest = :freebsd'
+          - 'ssh.sudo_command = "%c"'
+          - 'ssh.shell = "/bin/sh"'
+
+provisioner:
+    name: ansible
+    env:
+        ANSIBLE_VERBOSITY: 3
+verifier:
+    name: ansible
+    options:
+        become: true

--- a/molecule/system_settings_general/verify.yml
+++ b/molecule/system_settings_general/verify.yml
@@ -1,0 +1,6 @@
+---
+- name: Verify connectivity to server
+  hosts: all
+  tasks:
+    - name: Ping the server
+      ansible.builtin.ping:

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -368,36 +368,32 @@ class OPNsenseModuleConfig:
         _setting.text = value
 
     @property
-    def diff(self) -> Optional[Dict[str, str]]:
+    def diff(self) -> [Dict[dict, dict]]:
         """
         Compares the in-memory configuration with the configuration on the file path
         and returns a dictionary of differences.
 
         Returns:
-        - Optional[Dict[str, str]]: A dictionary containing the differences between
-          the in-memory configuration and the file-based configuration.
+        - Dict[dict, dict]: A dictionary containing the before and
+          after values (the in-memory configuration and the file-based configuration).
 
         Example:
-        - diff might return {'setting1': 'new_value', 'setting2': 'changed_value'}.
+        - diff might return {'before': {"foo": "bar"}, 'after': {"foo": "baz"}}.
         """
         file_config_tree = ElementTree.parse(self._config_path)
         file_config = file_config_tree.getroot()
 
         # Create a dictionary to store the differences
-        config_diff = {}
+        config_diff_before = {}
+        config_diff_after = {}
 
         for setting_name, xpath in self._config_map.items():
             if setting_name in ["php_requirements", "configure_functions"]:
                 continue
 
             # Find the setting in the file-based configuration
-            file_setting = file_config.find(xpath)
-
+            config_diff_before.update({xpath: file_config.find(xpath).text})
             # Find the setting in the in-memory configuration
-            in_memory_setting = self._config_xml_tree.find(xpath)
+            config_diff_after.update({xpath: self._config_xml_tree.find(xpath).text})
 
-            # Compare the values
-            if in_memory_setting.text != file_setting.text:
-                config_diff[setting_name] = in_memory_setting.text
-
-        return config_diff
+        return {"before": config_diff_before, "after": config_diff_after}

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -157,6 +157,7 @@ class OPNsenseModuleConfig:
         Returns:
         - bool: True if changes were saved, False if no changes were detected.
         """
+
         if self.changed:
             tree: ElementTree.ElementTree = ElementTree.ElementTree(
                 self._config_xml_tree

--- a/plugins/module_utils/module_index.py
+++ b/plugins/module_utils/module_index.py
@@ -127,4 +127,53 @@ VERSION_MAP = {
             },
         },
     },
+    "OPNsense 23.7": {
+        "system_settings_general": {
+            "hostname": "system/hostname",
+            "domain": "system/domain",
+            "timezone": "system/timezone",
+            # Add other mappings here
+            "php_requirements": [
+                "/usr/local/etc/inc/config.inc",
+                "/usr/local/etc/inc/util.inc",
+                "/usr/local/etc/inc/filter.inc",
+                "/usr/local/etc/inc/system.inc",
+                "/usr/local/etc/inc/interfaces.inc",
+            ],
+            "configure_functions": {
+                "system_timezone_configure": {
+                    "name": "system_timezone_configure",
+                    "configure_params": ["true"],
+                },
+                "system_trust_configure": {
+                    "name": "system_trust_configure",
+                    "configure_params": ["true"],
+                },
+                "system_hostname_configure": {
+                    "name": "system_hostname_configure",
+                    "configure_params": ["true"],
+                },
+                "system_hosts_generate": {
+                    "name": "system_hosts_generate",
+                    "configure_params": ["true"],
+                },
+                "system_resolvconf_generate": {
+                    "name": "system_resolvconf_generate",
+                    "configure_params": ["true"],
+                },
+                "plugins_configure_dns": {
+                    "name": "plugins_configure",
+                    "configure_params": ["'dns'", "true"],
+                },
+                "plugins_configure_dhcp": {
+                    "name": "plugins_configure",
+                    "configure_params": ["'dhcp'", "true"],
+                },
+                "filter_configure": {
+                    "name": "filter_configure",
+                    "configure_params": ["true"],
+                },
+            },
+        },
+    },
 }

--- a/plugins/module_utils/opnsense_utils.py
+++ b/plugins/module_utils/opnsense_utils.py
@@ -36,22 +36,19 @@ def run_function(
 
     # assemble php command
     php_cmd = f"{requirements_string} {configure_function}({params_string});"
-    cmd_result = {"stdout": "", "stderr": "", "returncode": 2}
     # run command
-    try:
-        cmd_result = subprocess.run(
-            [
-                "php",
-                "-r",
-                php_cmd,
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            check=True,  # raise exception if program fails
-        )
-    # handle subprocess process error in module using stderr
-    except subprocess.CalledProcessError:
-        pass
+    cmd_result = subprocess.run(
+        [
+            "php",
+            "-r",
+            php_cmd,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        # do not raise exception if program fails
+        # handle subprocess process error in module using stderr
+        check=False,
+    )
 
     return {
         "stdout": cmd_result.stdout.decode().strip(),

--- a/plugins/modules/system_settings_general.py
+++ b/plugins/modules/system_settings_general.py
@@ -158,6 +158,7 @@ def main():
     result = {
         "changed": False,
         "invocation": module.params,
+        "diff": None,
     }
 
     hostname_param = module.params.get("hostname")

--- a/plugins/modules/system_settings_general.py
+++ b/plugins/modules/system_settings_general.py
@@ -194,6 +194,12 @@ def main():
         if config.changed and not module.check_mode:
             config.save()
             result["opnsense_configure_output"] = config.apply_settings()
+            for cmd_result in result["opnsense_configure_output"]:
+                if cmd_result["rc"] != 0:
+                    module.fail_json(
+                        msg="Apply of the OPNsense settings failed",
+                        details=cmd_result,
+                    )
 
     # Return results
     module.exit_json(**result)

--- a/plugins/modules/system_settings_general.py
+++ b/plugins/modules/system_settings_general.py
@@ -1,0 +1,202 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Reto Kupferschmid <kupferschmid@puzzle.ch>, Puzzle ITC
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Example module: Show minimal functionality of OPNsenseConfig class"""
+
+__metaclass__ = type
+
+# https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html
+# fmt: off
+DOCUMENTATION = r'''
+---
+author:
+  - Reto Kupferschmid (@rekup)
+module: system_settings_general
+short_description: Configure general settings mainly concern network-related settings like the hostname.
+description:
+  - Module to configure general system settings
+options:
+  hostname:
+    description:
+      - "Hostname without domain, e.g.: V(firewall)"
+    type: str
+    required: false
+  domain:
+    description:
+      - The domain, e.g. V(mycorp.com), V(home), V(office), V(private), etc.
+      - Do not use V(local)as a domain name. It will cause local hosts running mDNS (avahi, bonjour, etc.) to be unable to resolve local hosts not running mDNS.
+    type: str
+    required: false
+  timezone:
+    description:
+      - The timezone e.g. V((Europe/Zurich), V(Etc/GMT+7), V(America/New_York), etc.
+      - A list of valid timezones can be found in the OPNsense webui or in the V(/usr/share/zoneinfo/) directory on your OPNsense.
+    type: str
+    required: false
+'''
+
+EXAMPLES = r'''
+- name: Set hostname to opnsense
+  puzzle.opnsense.system_settings_general:
+    hostname: "opnsense"
+
+- name: Set domain to mycorp.com
+  puzzle.opnsense.system_settings_general:
+    domain: mycorp.com
+
+- name: Set timezone to Europe/Zurich
+  puzzle.opnsense.system_settings_general:
+    timezone: Europe/Zurich
+'''
+
+RETURN = '''
+opnsense_configure_output:
+    description: A List of the executed OPNsense configure function along with their respective stdout, stderr and rc
+    returned: always
+    type: list
+    sample:
+      - function: system_timezone_configure
+        params:
+          - 'true'
+        rc: 0
+        stderr: ''
+        stderr_lines: []
+        stdout: 'Setting timezone: Europe/Zurich'
+        stdout_lines:
+          - 'Setting timezone: Europe/Zurich'
+      - function: system_trust_configure
+        params:
+          - 'true'
+        rc: 0
+        stderr: ''
+        stderr_lines: []
+        stdout: Writing trust files...done.
+        stdout_lines:
+          - Writing trust files...done.
+'''
+# fmt: on
+
+import os
+import re
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.puzzle.opnsense.plugins.module_utils.config_utils import (
+    OPNsenseModuleConfig,
+)
+
+
+def is_hostname(hostname: str) -> bool:
+    """
+    Validates hostnames
+
+    :param hostname: A string containing the hostname
+
+    :return: True if the provided hostname is valid, False if it's invalid
+    """
+
+    # https://github.com/opnsense/core/blob/cbaf7cee1f0a6fabd1ec4c752a5d169c402976dc/src/etc/inc/util.inc#L704
+    hostname_regex = (
+        r"^(?:(?:[a-z0-9_]|[a-z0-9_][a-z0-9_\-]"
+        r"*[a-z0-9_])\.)*(?:[a-z0-9_]|[a-z0-9_][a-z0-9_\-]*[a-z0-9_])$"
+    )
+    return re.match(hostname_regex, hostname) is not None
+
+
+def is_domain(domain: str) -> bool:
+    """
+    Validates domain
+
+    :param hostname: A string containing the domain
+
+    :return: True if the provided domain is valid, False if it's invalid
+    """
+
+    # https://github.com/opnsense/core/blob/cbaf7cee1f0a6fabd1ec4c752a5d169c402976dc/src/etc/inc/util.inc#L716
+    domain_regex = (
+        r"^(?:(?:[a-z0-9]|[a-z0-9][a-z0-9\-]*"
+        r"[a-z0-9])\.)*(?:[a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$"
+    )
+    return re.match(domain_regex, domain) is not None
+
+
+def is_timezone(tz: str) -> bool:
+    """
+    Validates timezones
+
+    :param tz: A string containing the timezone
+
+    :return: True if the provided timezone is valid, False if it's invalid
+    """
+    tz_path = os.path.join("/usr/share/zoneinfo/", tz)
+    return os.path.isfile(tz_path)
+
+
+def main():
+    """
+    Main function of the system_settings_general module
+    """
+
+    module_args = {
+        "domain": {"type": "str", "required": False},
+        "hostname": {"type": "str", "required": False},
+        "timezone": {"type": "str", "required": False},
+    }
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+        required_one_of=[
+            ["domain", "hostname", "timezone"],
+        ],
+    )
+
+    # https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html
+    # https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#return-block
+    result = {
+        "changed": False,
+        "invocation": module.params,
+    }
+
+    hostname_param = module.params.get("hostname")
+    domain_param = module.params.get("domain")
+    timezone_param = module.params.get("timezone")
+
+    with OPNsenseModuleConfig(module_name="system_settings_general") as config:
+        if hostname_param:
+            if not is_hostname(hostname_param):
+                module.fail_json(msg="Invalid hostname parameter specified")
+
+            if hostname_param != config.get("hostname"):
+                config.set(value=hostname_param, setting="hostname")
+
+        if domain_param:
+            if not is_domain(domain_param):
+                module.fail_json(msg="Invalid domain parameter specified")
+
+            if domain_param != config.get("domain"):
+                config.set(value=domain_param, setting="domain")
+
+        if timezone_param:
+            if not is_timezone(timezone_param):
+                module.fail_json(msg="Invalid timezone parameter specified")
+
+            if timezone_param != config.get("timezone"):
+                config.set(value=timezone_param, setting="timezone")
+
+        if config.changed:
+            result["diff"] = config.diff
+            result["changed"] = True
+
+        if config.changed and not module.check_mode:
+            config.save()
+            result["opnsense_configure_output"] = config.apply_settings()
+
+    # Return results
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/plugins/module_utils/test_config_utils.py
+++ b/tests/unit/plugins/module_utils/test_config_utils.py
@@ -349,7 +349,14 @@ def test_diff_on_change(sample_config_path):
         new_config.set(value="testtest", setting="hostname")
         diff = new_config.diff
 
-        assert diff == {"hostname": "testtest"}
+        assert diff == {
+            "before": {
+                "system/hostname": "test_name",
+            },
+            "after": {
+                "system/hostname": "testtest",
+            },
+        }
         new_config.save()
 
 
@@ -363,4 +370,4 @@ def test_diff_on_no_change(sample_config_path):
     """
     with OPNsenseModuleConfig("test_module", path=sample_config_path) as new_config:
         diff = new_config.diff
-        assert diff == {}
+        assert diff["before"] == diff["after"]

--- a/tests/unit/plugins/module_utils/test_opnsense_utils.py
+++ b/tests/unit/plugins/module_utils/test_opnsense_utils.py
@@ -74,5 +74,5 @@ def test_run_function(mock_subprocess_run: MagicMock):
     ]
 
     mock_subprocess_run.assert_called_with(
-        expected_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
+        expected_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
     )


### PR DESCRIPTION
* add diff property to `OPNsenseConfig` class which returns a dict with the config diff as required by ansible to display diffs using the `--diff` flag
* add `config_utils` which handles the required actions to apply changes in the System -> Settings -> General view
* add `system_settings_general` module with the ability to set hostname and domain

:warning: depends on https://github.com/puzzle/puzzle.opnsense/pull/39