### PR TITLE
Exclude python 3.6 for tests on ansible devel (2.15)

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -190,15 +190,18 @@ jobs:
           - '3.10'
         exclude:
           # Because ansible-test doesn't support Python 3.9 for Ansible 2.9
-          # and Python 3.10 is supported in 2.12 or later.
           - ansible: stable-2.9
             python: '3.9'
+          # and Python 3.10 is only supported in 2.12 or later.
           - ansible: stable-2.9
             python: '3.10'
           - ansible: stable-2.10
             python: '3.10'
           - ansible: stable-2.11
             python: '3.10'
+          # for Ansible >=2.15 Python 3.6 support has been deprecated
+          - ansible: devel
+            python: '3.6'
             
 
     steps:


### PR DESCRIPTION
Since Ansible 2.15 dropped support for Python 3.6, we need to exclude this in order to pass integration tests (See [Job #266](https://github.com/puzzle/puzzle.opnsense/actions/runs/6609367088/job/17968292062) )