### PR TITLE
Build back XML to dictionary translation layer

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,6 +8,8 @@ authors:
   - Lukas Grimm (github.com/ombre8)
   - Fabio Bertagna (github.com/dongiovanni83)
   - Philipp Matti (github.com/acteru)
+  - Reto Kupferschmid (github.com/rekup)
+  - Kilian Soltermann (github.com/killuuuhh)
 description: OPNsense collection for Ansible
 license_file: LICENSE
 tags:

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -65,7 +65,6 @@ class UnsupportedModuleSettingError(Exception):
     Exception raised when an attempt is made to access an invalid or unsupported setting in a Module.
     """
 
-    pass
 
 
 class OPNsenseModuleConfig:

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -324,7 +324,7 @@ class OPNsenseModuleConfig:
         cmd_output: list = []
 
         # run configure functions with all required php dependencies and store their output.
-        for key, value in configure_functions.items():
+        for value in configure_functions.values():
             cmd_output.append(
                 opnsense_utils.run_function(
                     php_requirements=php_requirements,

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -58,7 +58,6 @@ class UnsupportedVersionForModule(Exception):
     Exception raised when no configuration map could be found for a given module and version.
     """
 
-    pass
 
 
 class UnsupportedModuleSettingError(Exception):

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -184,7 +184,7 @@ class OPNsenseModuleConfig:
             != ElementTree.tostring(self._config_xml_tree).decode()
         )
 
-    def get_setting(self, setting_name: str) -> Element:
+    def get(self, setting_name: str) -> Element:
         """
         Retrieves a specific configuration setting for a setting name.
 
@@ -285,7 +285,7 @@ class OPNsenseModuleConfig:
         # return list
         return configure_functions
 
-    def apply_setting(self) -> List[str]:
+    def apply_settings(self) -> List[str]:
         """
         Retrieves and applies configuration-specific PHP requirements and configure functions for
         a given module.
@@ -335,7 +335,7 @@ class OPNsenseModuleConfig:
 
         return cmd_output
 
-    def set_module_setting(self, value: str, setting: str) -> None:
+    def set(self, value: str, setting: str) -> None:
         """
         Sets a specific configuration setting for a given module.
 

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -44,7 +44,6 @@ class ModuleMisconfigurationError(Exception):
     plugins.module_utils.module_index.VERSION_MAP.
     """
 
-    pass
 
 
 class UnsupportedOPNsenseVersion(Exception):

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -61,7 +61,6 @@ class UnsupportedModuleSettingError(Exception):
     """
 
 
-
 class OPNsenseModuleConfig:
     """
     A class to handle OPNsense module configuration.

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -36,7 +36,6 @@ class MissingConfigDefinitionForModuleError(Exception):
     """
 
 
-
 class ModuleMisconfigurationError(Exception):
     """
     Exception raised when module configurations are not in the expected format as defined in the

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -49,7 +49,6 @@ class UnsupportedOPNsenseVersion(Exception):
     """
 
 
-
 class UnsupportedVersionForModule(Exception):
     """
     Exception raised when no configuration map could be found for a given module and version.

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -51,7 +51,6 @@ class UnsupportedOPNsenseVersion(Exception):
     Exception raised when an OPNsense version is not supported by the collection.
     """
 
-    pass
 
 
 class UnsupportedVersionForModule(Exception):

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -27,7 +27,6 @@ class OPNSenseConfigUsageError(Exception):
     Exception raised for errors related to improper usage of the OPNSense module.
     """
 
-    pass
 
 
 class MissingConfigDefinitionForModuleError(Exception):

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -55,7 +55,6 @@ class UnsupportedVersionForModule(Exception):
     """
 
 
-
 class UnsupportedModuleSettingError(Exception):
     """
     Exception raised when an attempt is made to access an invalid or unsupported setting in a Module.

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -28,7 +28,6 @@ class OPNSenseConfigUsageError(Exception):
     """
 
 
-
 class MissingConfigDefinitionForModuleError(Exception):
     """
     Exception raised when a required config definition is missing for a module in the

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -43,7 +43,6 @@ class ModuleMisconfigurationError(Exception):
     """
 
 
-
 class UnsupportedOPNsenseVersion(Exception):
     """
     Exception raised when an OPNsense version is not supported by the collection.

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -36,7 +36,6 @@ class MissingConfigDefinitionForModuleError(Exception):
     'php_requirements' and 'configure_functions'.
     """
 
-    pass
 
 
 class ModuleMisconfigurationError(Exception):

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -1,319 +1,240 @@
 # Copyright: (c) 2023, Puzzle ITC
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-"""Utilities for interactions with the OPNsense config file /conf/config.xml"""
+"""
+This module provides utilities for interactions with the OPNsense config file located at
+/conf/config.xml. It includes classes and methods to read, modify, and manage the configuration
+specific to different modules and OPNsense versions.
+"""
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from typing import Any, List, Optional, Union
+from typing import List, Optional, Dict
 from xml.etree import ElementTree
+from xml.etree.ElementTree import Element
 
 from ansible_collections.puzzle.opnsense.plugins.module_utils import (
-    xml_utils,
     version_utils,
     opnsense_utils,
+    module_index,
 )
 
 
 class OPNSenseConfigUsageError(Exception):
     """
-    Error Class to be raised in improper module usage
+    Exception raised for errors related to improper usage of the OPNSense module.
     """
+
+    pass
 
 
 class MissingConfigDefinitionForModuleError(Exception):
     """
-    Raised when a module misses a required config definition in the
-    plugins.module_utils.module_index.VERSION_MAP. Required configs must be
+    Exception raised when a required config definition is missing for a module in the
+    plugins.module_utils.module_index.VERSION_MAP. Required configs must include
     'php_requirements' and 'configure_functions'.
     """
+
+    pass
 
 
 class ModuleMisconfigurationError(Exception):
     """
-    Raised when module configs are not in the expected format in the
+    Exception raised when module configurations are not in the expected format as defined in the
     plugins.module_utils.module_index.VERSION_MAP.
     """
 
+    pass
 
-class OPNsenseConfig:
+
+class UnsupportedOPNsenseVersion(Exception):
     """
-    A utility class for managing and interacting with the OPNsense configuration file
-    (/conf/config.xml). It provides methods for retrieving, modifying, and applying settings
-    specific to different modules based on version-specific requirements.
-
-    The class facilitates operations such as fetching PHP requirements, retrieving and setting
-    configuration values, and handling version-specific configurations. It uses a context manager
-    to ensure safe handling of the configuration file, allowing changes to be made within a managed
-    context.
-
-    Usage:
-       with OPNsenseConfig(version_map) as config:
-           # Retrieve a configuration value
-           value = config.get_module_setting('module', 'setting')
-
-           # Modify a configuration value
-           config.set_module_setting('value', 'module', 'setting')
-
-           # Delete a configuration value
-           config.del_module_setting('module', 'setting')
-
-           # Apply module-specific settings
-           outputs = config.apply_module_setting('module')
-
-           # Save changes to the configuration file
-           config.save()
-
-    Note:
-       - The context manager ensures that any changes made to the configuration are saved
-         before exiting the block. It also provides error handling to ensure that changes
-         are not lost.
-
-    Parameters:
-    - version_map (dict): A dictionary mapping module versions to their respective settings.
-    - path (str, optional): The file path to the OPNsense configuration file. Defaults to
-      "/conf/config.xml".
-
-    Methods like _get_php_requirements, _get_configure_functions, etc., offer more granular
-    control for advanced operations. They are primarily used internally but can be used
-    externally for custom configurations.
-
-    This class raises OPNSenseConfigUsageError for version compatibility issues or other
-    configuration-related errors.
+    Exception raised when an OPNsense version is not supported by the collection.
     """
 
+    pass
+
+
+class UnsupportedVersionForModule(Exception):
+    """
+    Exception raised when no configuration map could be found for a given module and version.
+    """
+
+    pass
+
+
+class UnsupportedModuleSettingError(Exception):
+    """
+    Exception raised when an attempt is made to access an invalid or unsupported setting in a Module.
+    """
+
+    pass
+
+
+class OPNsenseModuleConfig:
+    """
+    A class to handle OPNsense module configuration.
+
+    This class provides methods to load, modify, and save configurations specific to OPNsense modules.
+    It also includes functionality to apply settings and manage PHP requirements and configure functions
+    based on the OPNsense version and module name.
+
+    Attributes:
+        _config_xml_tree (Element): The XML tree of the configuration file.
+        _config_path (str): The file path of the configuration.
+        _config_map (dict): The mapping of settings and their XPath in the XML tree.
+        _module_name (str): The name of the module.
+        _opnsense_version (str): The OPNsense version.
+    """
+
+    _config_xml_tree: Element
     _config_path: str
-    _config_dict: dict
+    _config_map: dict
+    _module_name: str
+    _opnsense_version: str
 
-    def __init__(self, version_map: dict = None, path: str = "/conf/config.xml"):
+    def __init__(self, module_name: str, path: str = "/conf/config.xml"):
         """
-        Initializes an instance of OPNsenseConfig.
+        Initializes the OPNsenseModuleConfig class.
 
-        :param path:  The path to the OPNsense config file (default: "/conf/config.xml").
-        :param version_map:  The version_map of the specific module.
+        Args:
+            module_name (str): The name of the module.
+            path (str, optional): The path to the config.xml file. Defaults to "/conf/config.xml".
         """
+        self._module_name = module_name
         self._config_path = path
-        self._config_dict = self._parse_config_from_file()
-        self.version_map = version_map
+        self._config_xml_tree = self._load_config()
+        self._opnsense_version = version_utils.get_opnsense_version()
 
-        self.version = version_utils.get_opnsense_version()
+        try:
+            version_map: dict = module_index.VERSION_MAP[self._opnsense_version]
+        except KeyError as ke:
+            raise UnsupportedOPNsenseVersion(
+                f"OPNsense version '{self._opnsense_version}' not supported by puzzle.opnsense collection"
+            ) from ke
 
-    def __enter__(self) -> "OPNsenseConfig":
+        if self._module_name not in version_map:
+            raise UnsupportedVersionForModule(
+                f"Module '{self._module_name}' not supported "
+                f"for OPNsense version '{self._opnsense_version}'."
+            )
+
+        self._config_map = version_map[self._module_name]
+
+    def _load_config(self) -> Element:
+        """
+        Loads the config.xml file and returns its root element.
+
+        Returns:
+            Element: The root element of the config.xml file.
+        """
+        return ElementTree.parse(self._config_path).getroot()
+
+    def __enter__(self) -> "OPNsenseModuleConfig":
+        """
+        Enters the context manager for the OPNsenseModuleConfig class.
+
+        Returns:
+            OPNsenseModuleConfig: The instance of OPNsenseModuleConfig.
+        """
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """
-        Exits the context manager and checks if the config has changed and not saved.
-        :raises RuntimeError: If changes are present which have not been saved.
-        :return:
+        Exits the context manager for OPNsenseModuleConfig.
+
+        Checks if the configuration has changed and not been saved, raising a RuntimeError if so.
+
+        Args:
+            exc_type: The exception type.
+            exc_val: The exception value.
+            exc_tb: The traceback.
+
+        Raises:
+            RuntimeError: If there are unsaved changes in the configuration.
         """
         if exc_type:
             raise exc_type(f"Exception occurred: {exc_val}")
         if self.changed:
             raise RuntimeError("Config has changed. Cannot exit without saving.")
 
-    def __getitem__(self, key: Any) -> Any:
-        return self._config_dict[key]
-
-    def __setitem__(self, key: Any, value: Any) -> None:
-        self._config_dict[key] = value
-
-    def __delitem__(self, key: Any) -> None:
-        del self._config_dict[key]
-
-    def __contains__(self, key: Any) -> bool:
-        return key in self._config_dict
-
-    def _parse_config_from_file(self) -> dict:
-        _config_root: ElementTree = ElementTree.parse(self._config_path).getroot()
-        return xml_utils.etree_to_dict(_config_root)["opnsense"] or {}
-
     def save(self) -> bool:
         """
-        Saves the config dictionary to the config file if changes have been made.
+        Saves the config to the file if changes have been made.
 
-        :return: True if changes were saved, False if no changes were detected.
+        Returns:
+        - bool: True if changes were saved, False if no changes were detected.
         """
         if self.changed:
-            new_config_root = xml_utils.dict_to_etree("opnsense", self._config_dict)[0]
-            new_tree = ElementTree.ElementTree(new_config_root)
-            new_tree.write(self._config_path, encoding="utf-8", xml_declaration=True)
-            self._config_dict = self._parse_config_from_file()
+            tree: ElementTree.ElementTree = ElementTree.ElementTree(
+                self._config_xml_tree
+            )
+            tree.write(self._config_path, encoding="utf-8", xml_declaration=True)
+            self._config_xml_tree = self._load_config()
             return True
         return False
 
     @property
     def changed(self) -> bool:
-        """
-        Enters the context manager.
+        """Checks if changes have been made to the config."""
+        return (
+            ElementTree.tostring(self._load_config()).decode()
+            != ElementTree.tostring(self._config_xml_tree).decode()
+        )
 
-        :return: True if changes have been made to the config, False otherwise.
+    def get_setting(self, setting_name: str) -> Element:
         """
-        orig_dict = self._parse_config_from_file()
-        return orig_dict != self._config_dict
-
-    def _get_module_version_map(self, module: str) -> dict:
-        """
-        Retrieves the version-specific mapping for a specified module.
-
-        This function accesses the `version_map` attribute to fetch the mapping for the current
-        version. If the mapping for the specified version exists, it returns the mapping;
-        otherwise, it raises an OPNSenseConfigUsageError.
+        Retrieves a specific configuration setting for a setting name.
 
         Parameters:
-        - module (str): The name of the module for which the version-specific mapping is required.
+        - setting_name (str): The name of the setting to retrieve.
 
         Returns:
-        - dict: A dictionary containing the version-specific mapping for the given module.
-
-        Raises:
-        - OPNSenseConfigUsageError: If the current version is not supported for the given module,
-          indicated by the absence of the version key in the `version_map`.
-
-        Example:
-        - Calling _get_module_version_map('network') for an instance with version '1.0' might
-          return the mapping for the 'network' module if version '1.0' is present in `version_map`.
-
-        Note:
-        - This function is critical for ensuring that the configuration aligns with the specific
-          version requirements of a module.
+        - Element: The retrieved setting element.
         """
-
-        if self.version_map.get(self.version):
-            return self.version_map.get(self.version)
-
-        raise OPNSenseConfigUsageError(f"Version {self.version} not supported in module {module}")
-
-    def _search_map(self, dictionary, key) -> Optional[str]:
-        """
-        Recursively search for a key in a nested dictionary.
-
-        This function traverses through a nested dictionary structure to find the value associated
-        with the specified key. It searches through all levels of nested dictionaries until it finds
-        the key or exhausts all possibilities.
-
-        Parameters:
-        - dictionary (dict): The dictionary to search. This can be a multi-level nested dictionary.
-        - key (str): The key to search for in the dictionary.
-
-        Returns:
-        - The value associated with the found key, or None if the key is not found in the dict.
-
-        Example:
-        - Given the dictionary `{"interfaces": {"wan": {"if": 'interfaces/wan/if'}}}`
-        and the key `'if'`, the function will return `'interfaces/wan/if'`.
-        """
-
-        if not isinstance(dictionary, dict):
-            return None
-
-        for k, v in dictionary.items():
-            if k == key:
-                return v
-            result = self._search_map(v, key)
-            if result is not None:
-                return result
-
-    def _get_xpath(self, module: str, setting: str) -> Union[str, dict]:
-        """
-        Retrieves the XPath for a given module and setting based on the version-specific mapping.
-
-        This function looks up the XPath in a version-specific mapping dictionary using the provided
-        module and setting names. If the setting is directly within the module, it returns it;
-        otherwise, it performs a recursive search if the setting is nested within the module.
-
-        Parameters:
-        - module (str): The name of the module for which the XPath is sought.
-        - setting (str): The specific setting within the module whose XPath is needed.
-
-        Returns:
-        - Union[str, dict, None]: The XPath as a string or dict if found, or None if the module
-        or setting cannot be found or is not available.
-
-        Raises:
-        - OPNSenseConfigUsageError: If the version-specific `version_map` is not set during the
-        initialization of the instance.
-
-        Example:
-        - Calling _get_xpath('network', 'interface') might return 'network/interface' or a
-        dictionary of nested settings if 'interface' is a nested setting within 'network'.
-
-        Note:
-        - The function emphasizes the importance of a properly initialized `version_map`.The absence
-        of the module in the map or the setting within the module leads to a return value of None.
-        """
-
-        if not self.version_map:
-            raise OPNSenseConfigUsageError(
-                "Module specific version_map was not set during initalization"
+        if setting_name not in self._config_map:
+            raise UnsupportedModuleSettingError(
+                f"Setting '{setting_name}' is not supported in module '{self._module_name}' "
+                f"for OPNsense version '{self._opnsense_version}'"
             )
+        return self._config_xml_tree.find(self._config_map[setting_name])
 
-        map_dict = self._get_module_version_map(module=module)
-
-        # Check if the provided module is in the map
-        if module in map_dict and setting in map_dict[module]:
-            # If the setting is directly within the module, return it
-            return map_dict[module][setting]
-        elif module in map_dict:
-            # If the setting is nested, search recursively
-            return self._search_map(map_dict[module], setting)
-
-        raise OPNSenseConfigUsageError("Module specific xpath was not found")
-
-    def _get_php_requirements(self, module: str) -> list:
+    def _get_php_requirements(self) -> list:
         """
         Retrieves the PHP requirements for a given module from a version map.
-
-        This method extracts PHP requirements for the specified module
-        from a predefined map (VERSION_MAP). It ensures that these
-        requirements are defined and correctly formatted as a list. In cases
-        where requirements are missing or improperly formatted, it raises
-        specific exceptions.
-
-        Parameters:
-        - module (str): The name of the module.
 
         Returns:
         - list: PHP requirements for the module.
 
         Raises:
         - MissingConfigDefinitionForModuleError: If no PHP requirements
-        are defined in the version map for the module.
+          are defined in the version map for the module.
         - ModuleMisconfigurationError: If PHP requirements are not in list format.
-
-        The method enforces the presence and correct format of PHP
-        requirements for the specified OPNsense version.
-
-        Example:
-            php_requirements = _get_php_requirements("some_module")
-            # Returns the list of PHP requirements for "some_module"
         """
 
-        map_dict: dict = self._get_module_version_map(module=module)
-
-        php_requirements: Optional[list] = map_dict.get("php_requirements")
+        php_requirements: Optional[list] = self._config_map.get("php_requirements")
 
         # enforce presence of php_requirements in the VERSION_MAP
         if php_requirements is None:
             raise MissingConfigDefinitionForModuleError(
-                f"Module {module} has no php_requirements defined in "
+                f"Module '{self._module_name}' has no php_requirements defined in "
                 f"the plugins.module_utils.module_index.VERSION_MAP for given "
-                f"OPNsense version {self.version}."
+                f"OPNsense version '{self._opnsense_version}'."
             )
 
         # ensure php_requirements are defined as a list
         if not isinstance(php_requirements, list):
             raise ModuleMisconfigurationError(
-                f"PHP requirements (php_requirements) for the module {module} are "
-                f"not provided as a list in the VERSION_MAP using OPNsense version {self.version}."
+                f"PHP requirements (php_requirements) for the module '{self._module_name}' are "
+                f"not provided as a list in the VERSION_MAP using OPNsense version '{self._opnsense_version}'."
             )
 
         # return list
         return php_requirements
 
-    def _get_configure_functions(self, module: str) -> dict:
+    def _get_configure_functions(self) -> dict:
         """
         Retrieves configure functions for a module from version-specific mapping.
 
@@ -342,153 +263,29 @@ class OPNsenseConfig:
             Functionality depends on accurate and complete version_map.
         """
 
-        map_dict: dict = self._get_module_version_map(module=module)
-
-        configure_functions: Optional[dict] = map_dict.get("configure_functions")
+        configure_functions: Optional[dict] = self._config_map.get(
+            "configure_functions"
+        )
 
         # enforce presence of configure_functions in the VERSION_MAP
         if configure_functions is None:
             raise MissingConfigDefinitionForModuleError(
-                f"Module {module} has no configure_functions defined in "
+                f"Module '{self._module_name}' has no configure_functions defined in "
                 f"the plugins.module_utils.module_index.VERSION_MAP for given "
-                f"OPNsense version {self.version}."
+                f"OPNsense version '{self._opnsense_version}'."
             )
 
         # ensure configure_functions are defined as a list
         if not isinstance(configure_functions, dict):
             raise ModuleMisconfigurationError(
-                f"Configure functions (configure_functions) for the module {module} are "
-                f"not provided as a list in the VERSION_MAP using OPNsense version {self.version}."
+                f"Configure functions (configure_functions) for the module '{self._module_name}' are "
+                f"not provided as a list in the VERSION_MAP using OPNsense version '{self._opnsense_version}'."
             )
 
         # return list
         return configure_functions
 
-    def set_module_setting(self, value: str, module: str, setting: str) -> None:
-        """
-        Sets a specific configuration setting for a given module.
-
-        This function sets a value in the configuration for a specified module and setting. It
-        first retrieves the XPath using _get_xpath, then updates the value at the specified
-        setting in a copy of the _config_dict.
-
-        Parameters:
-        - value (str): The value to set for the specific setting.
-        - module (str): The module where the setting resides.
-        - setting (str): The specific setting within the module to update.
-
-        Steps:
-        - Retrieve XPath for the module and setting.
-        - Create a copy of _config_dict.
-        - Traverse the XPath, updating nested dictionaries as needed.
-        - Set the value at the final key in the XPath.
-
-        Example:
-        - Calling set_module_setting('192.168.1.1', 'network', 'gateway') will set the
-          'gateway' setting under the 'network' module to '192.168.1.1'.
-
-        Note:
-        - This function directly modifies the configuration and should be used with caution.
-        """
-
-        # get xpath from key_mapping
-        xpath = self._get_xpath(module=module, setting=setting)
-
-        # create a copy of the _config_dict
-        _config_dict = self._config_dict.copy()
-
-        # iterate over xpath value to get specific key
-        keys = xpath.split("/")
-
-        for key in keys[:-1]:
-            _config_dict = _config_dict.setdefault(key, {})
-
-        # Update the final value
-        _config_dict[keys[-1]] = value
-
-    def del_module_setting(self, module: str, setting: str) -> None:
-        """
-        Deletes a specific configuration setting for a given module.
-
-        This function deletes a setting in the configuration for a specified module. It retrieves
-        the XPath for the setting using _get_xpath, then traverses the XPath in a copy of the
-        _config_dict to set the specified setting's value to None.
-
-        Parameters:
-        - module (str): The module where the setting resides.
-        - setting (str): The specific setting within the module to delete.
-
-        Steps:
-        - Retrieve XPath for the module and setting.
-        - Create a copy of _config_dict.
-        - Traverse the XPath, updating nested dictionaries as needed.
-        - Set the value at the final key in the XPath to None.
-
-        Example:
-        - Calling del_module_setting('network', 'gateway') will delete the 'gateway' setting
-          under the 'network' module.
-
-        Note:
-        - This function directly modifies the configuration, effectively deleting the setting.
-          Use with caution.
-        """
-
-        # get xpath from key_mapping
-        xpath = self._get_xpath(module=module, setting=setting)
-
-        # create a copy of the _config_dict
-        _config_dict = self._config_dict.copy()
-
-        # iterate over xpath value to get specific key
-        keys = xpath.split("/")
-
-        for key in keys[:-1]:
-            _config_dict = _config_dict.setdefault(key, {})
-
-        # Update the final value
-        _config_dict[keys[-1]] = None
-
-    def get_module_setting(self, module: str, setting: str) -> str:
-        """
-        Retrieves a specific configuration setting for a given module.
-
-        This function fetches a setting from the configuration for a specified module. It first
-        obtains the XPath for the setting using _get_xpath, and then traverses this path in a copy
-        of the _config_dict to find the desired setting's value.
-
-        Parameters:
-        - module (str): The module where the setting resides.
-        - setting (str): The specific setting within the module to retrieve.
-
-        Steps:
-        - Retrieve XPath for the module and setting.
-        - Create a copy of _config_dict.
-        - Traverse the XPath to find the specific key.
-        - Return the value associated with the key.
-
-        Example:
-        - Calling get_module_setting('network', 'gateway') will return the value of the 'gateway'
-          setting under the 'network' module.
-
-        Note:
-        - This function navigates through configuration, returning the value of the specified
-          setting. Ensure the setting path exists to avoid key errors.
-        """
-
-        # get xpath from key_mapping
-        xpath = self._get_xpath(module=module, setting=setting)
-
-        # create a copy of the _config_dict
-        _config_dict = self._config_dict.copy()
-
-        # iterate over xpath value to get specific key
-        for key in xpath.split("/"):
-            _config_dict = _config_dict[key]
-
-        # return key
-        return _config_dict
-
-    def apply_module_setting(self, module: str) -> List[str]:
+    def apply_setting(self) -> List[str]:
         """
         Retrieves and applies configuration-specific PHP requirements and configure functions for
         a given module.
@@ -518,16 +315,15 @@ class OPNsenseConfig:
           each module, as per the version-specific configuration.
         """
 
-        # get version and module specific php_requirements
-        php_requirements = self._get_php_requirements(module=module, setting="php_requirements")
+        # get module specific php_requirements
+        php_requirements: list = self._get_php_requirements()
 
-        # get version and module specific configure_functions
-        configure_functions = self._get_configure_functions(
-            module=module, setting="configure_functions"
-        )
+        # get module specific configure_functions
+        configure_functions: dict = self._get_configure_functions()
 
-        cmd_output = []
+        cmd_output: list = []
 
+        # run configure functions with all required php dependencies and store their output.
         for key, value in configure_functions.items():
             cmd_output.append(
                 opnsense_utils.run_function(
@@ -538,3 +334,76 @@ class OPNsenseConfig:
             )
 
         return cmd_output
+
+    def set_module_setting(self, value: str, setting: str) -> None:
+        """
+        Sets a specific configuration setting for a given module.
+
+        This function sets a value in the configuration for a specified module and setting. It
+        first retrieves the XPath using _get_xpath, then updates the value at the specified
+        setting in a copy of the _config_dict.
+
+        Parameters:
+        - value (str): The value to set for the specific setting.
+        - module (str): The module where the setting resides.
+        - setting (str): The specific setting within the module to update.
+
+        Steps:
+        - Retrieve XPath for the module and setting.
+        - Create a copy of _config_dict.
+        - Traverse the XPath, updating nested dictionaries as needed.
+        - Set the value at the final key in the XPath.
+
+        Example:
+        - Calling set_module_setting('192.168.1.1', 'network', 'gateway') will set the
+          'gateway' setting under the 'network' module to '192.168.1.1'.
+
+        Note:
+        - This function directly modifies the configuration and should be used with caution.
+        """
+
+        # get xpath from key_mapping
+        xpath = self._config_map.get(setting)
+
+        # create a copy of the _config_dict
+        _setting: Element = self._config_xml_tree.find(xpath)
+
+        if _setting.text in [None, "", " "]:
+            raise NotImplementedError("Currently only text settings supported")
+
+        _setting.text = value
+
+    @property
+    def diff(self) -> Optional[Dict[str, str]]:
+        """
+        Compares the in-memory configuration with the configuration on the file path
+        and returns a dictionary of differences.
+
+        Returns:
+        - Optional[Dict[str, str]]: A dictionary containing the differences between
+          the in-memory configuration and the file-based configuration.
+
+        Example:
+        - diff might return {'setting1': 'new_value', 'setting2': 'changed_value'}.
+        """
+        file_config_tree = ElementTree.parse(self._config_path)
+        file_config = file_config_tree.getroot()
+
+        # Create a dictionary to store the differences
+        config_diff = {}
+
+        for setting_name, xpath in self._config_map.items():
+            if setting_name in ["php_requirements", "configure_functions"]:
+                continue
+
+            # Find the setting in the file-based configuration
+            file_setting = file_config.find(xpath)
+
+            # Find the setting in the in-memory configuration
+            in_memory_setting = self._config_xml_tree.find(xpath)
+
+            # Compare the values
+            if in_memory_setting.text != file_setting.text:
+                config_diff[setting_name] = in_memory_setting.text
+
+        return config_diff

--- a/plugins/module_utils/module_index.py
+++ b/plugins/module_utils/module_index.py
@@ -1,0 +1,125 @@
+#  Copyright: (c) 2023, Puzzle ITC
+#  GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+VERSION_MAP is a dictionary that defines the mapping of configuration settings, PHP requirements,
+and configure functions for different versions of OPNsense. Each key in this dictionary represents
+a specific version of OPNsense, and the value is another dictionary that outlines the configurations
+for that version.
+
+Structure of VERSION_MAP:
+- The top-level keys are strings representing OPNsense versions (e.g., "OPNsense 22.7 (amd64/OpenSSL)").
+- Each value under a version key is a nested dictionary that maps module names to their specific configurations.
+- Each module's configuration includes keys for settings (with XPath values), PHP requirements, and configure functions.
+
+For example, the 'system_settings_general' module for "OPNsense 22.7 (amd64/OpenSSL)" includes:
+- Setting mappings: These are key-value pairs where the key is a friendly name for a setting (e.g., 'hostname'),
+  and the value is the XPath in the OPNsense configuration file to access this setting (e.g., 'system/hostname').
+- PHP requirements: A list of file paths required for executing the configure functions when applying changes.
+- Configure functions: A dictionary mapping function names to their details. Each function detail includes
+  the function name and any parameters required to execute the function.
+
+This map is essential for dynamically configuring modules based on the OPNsense version and provides
+a centralized definition for various configurations across different OPNsense versions.
+"""
+
+VERSION_MAP = {
+    "OPNsense 22.7 (amd64/OpenSSL)": {
+        "system_settings_general": {
+            "hostname": "system/hostname",
+            "domain": "system/domain",
+            "timezone": "system/timezone",
+            # Add other mappings here.
+            "php_requirements": [
+                "/usr/local/etc/inc/config.inc",
+                "/usr/local/etc/inc/util.inc",
+                "/usr/local/etc/inc/filter.inc",
+                "/usr/local/etc/inc/system.inc",
+                "/usr/local/etc/inc/interfaces.inc",
+            ],
+            "configure_functions": {
+                "system_timezone_configure": {
+                    "name": "system_timezone_configure",
+                    "configure_params": ["true"],
+                },
+                "system_trust_configure": {
+                    "name": "system_trust_configure",
+                    "configure_params": ["true"],
+                },
+                "system_hostname_configure": {
+                    "name": "system_hostname_configure",
+                    "configure_params": ["true"],
+                },
+                "system_hosts_generate": {
+                    "name": "system_hosts_generate",
+                    "configure_params": ["true"],
+                },
+                "system_resolvconf_generate": {
+                    "name": "system_resolvconf_generate",
+                    "configure_params": ["true"],
+                },
+                "plugins_configure_dns": {
+                    "name": "plugins_configure",
+                    "configure_params": ["'dns'", "true"],
+                },
+                "plugins_configure_dhcp": {
+                    "name": "plugins_configure",
+                    "configure_params": ["'dhcp'", "true"],
+                },
+                "filter_configure": {
+                    "name": "filter_configure",
+                    "configure_params": ["true"],
+                },
+            },
+        }
+    },
+    "OPNsense 23.1": {
+        "system_settings_general": {
+            "hostname": "system/hostname",
+            "domain": "system/domain",
+            "timezone": "system/timezone",
+            # Add other mappings here
+            "php_requirements": [
+                "/usr/local/etc/inc/config.inc",
+                "/usr/local/etc/inc/util.inc",
+                "/usr/local/etc/inc/filter.inc",
+                "/usr/local/etc/inc/system.inc",
+                "/usr/local/etc/inc/interfaces.inc",
+            ],
+            "configure_functions": {
+                "system_timezone_configure": {
+                    "name": "system_timezone_configure",
+                    "configure_params": ["true"],
+                },
+                "system_trust_configure": {
+                    "name": "system_trust_configure",
+                    "configure_params": ["true"],
+                },
+                "system_hostname_configure": {
+                    "name": "system_hostname_configure",
+                    "configure_params": ["true"],
+                },
+                "system_hosts_generate": {
+                    "name": "system_hosts_generate",
+                    "configure_params": ["true"],
+                },
+                "system_resolvconf_generate": {
+                    "name": "system_resolvconf_generate",
+                    "configure_params": ["true"],
+                },
+                "plugins_configure_dns": {
+                    "name": "plugins_configure",
+                    "configure_params": ["'dns'", "true"],
+                },
+                "plugins_configure_dhcp": {
+                    "name": "plugins_configure",
+                    "configure_params": ["'dhcp'", "true"],
+                },
+                "filter_configure": {
+                    "name": "filter_configure",
+                    "configure_params": ["true"],
+                },
+            },
+        },
+    },
+}

--- a/tests/unit/plugins/module_utils/test_config_utils.py
+++ b/tests/unit/plugins/module_utils/test_config_utils.py
@@ -159,7 +159,7 @@ def test_unsupported_module_setting(sample_config_path):
             match="Setting 'unsupported' is not supported in module 'test_module' "
             "for OPNsense version 'OPNsense Test'",
         ):
-            _ = new_config.get_setting("unsupported")
+            _ = new_config.get("unsupported")
 
 
 def test_php_requirements_must_be_present(sample_config_path):
@@ -287,7 +287,7 @@ def test_changed(sample_config_path):
     - sample_config_path (str): The path to the temporary test configuration file.
     """
     with OPNsenseModuleConfig("test_module", path=sample_config_path) as new_config:
-        new_config.set_module_setting(value="testtest", setting="hostname")
+        new_config.set(value="testtest", setting="hostname")
         assert new_config.changed
         new_config.save()
 
@@ -300,7 +300,7 @@ def test_get_setting(sample_config_path):
     - sample_config_path (str): The path to the temporary test configuration file.
     """
     with OPNsenseModuleConfig("test_module", path=sample_config_path) as new_config:
-        hostname_setting: Element = new_config.get_setting("hostname")
+        hostname_setting: Element = new_config.get("hostname")
         assert isinstance(hostname_setting, Element)
         assert "test_name" == hostname_setting.text
         new_config.save()
@@ -314,7 +314,7 @@ def test_save_on_changed(sample_config_path):
     - sample_config_path (str): The path to the temporary test configuration file.
     """
     with OPNsenseModuleConfig("test_module", path=sample_config_path) as new_config:
-        new_config.set_module_setting(value="testtest", setting="hostname")
+        new_config.set(value="testtest", setting="hostname")
         assert new_config.save()
 
 
@@ -338,7 +338,7 @@ def test_diff_on_change(sample_config_path):
     - sample_config_path (str): The path to the temporary test configuration file.
     """
     with OPNsenseModuleConfig("test_module", path=sample_config_path) as new_config:
-        new_config.set_module_setting(value="testtest", setting="hostname")
+        new_config.set(value="testtest", setting="hostname")
         diff = new_config.diff
 
         assert diff == {"hostname": "testtest"}

--- a/tests/unit/plugins/module_utils/test_config_utils.py
+++ b/tests/unit/plugins/module_utils/test_config_utils.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-__metaclass__ = type
+__metaclass__val = type
 
 import os
 from tempfile import NamedTemporaryFile
@@ -122,9 +122,9 @@ def test_unsupported_opnsense_version(
     """
     with pytest.raises(
         UnsupportedOPNsenseVersion,
-        match=f"OPNsense version 'OPNsense X.X.X' not supported by puzzle.opnsense collection",
+        match="OPNsense version 'OPNsense X.X.X' not supported by puzzle.opnsense collection",
     ):
-        _ = OPNsenseModuleConfig(module_name="test_module", path=sample_config_path)
+        _val = OPNsenseModuleConfig(module_name="test_module", path=sample_config_path)
 
 
 def test_unsupported_module(sample_config_path):
@@ -140,7 +140,7 @@ def test_unsupported_module(sample_config_path):
         match=r"Module 'unsupported_module' not supported "
         "for OPNsense version 'OPNsense Test'.",
     ):
-        _ = OPNsenseModuleConfig(
+        _val = OPNsenseModuleConfig(
             module_name="unsupported_module", path=sample_config_path
         )
 
@@ -159,7 +159,7 @@ def test_unsupported_module_setting(sample_config_path):
             match="Setting 'unsupported' is not supported in module 'test_module' "
             "for OPNsense version 'OPNsense Test'",
         ):
-            _ = new_config.get("unsupported")
+            _val = new_config.get("unsupported")
 
 
 def test_php_requirements_must_be_present(sample_config_path):
@@ -176,10 +176,10 @@ def test_php_requirements_must_be_present(sample_config_path):
         with pytest.raises(
             MissingConfigDefinitionForModuleError,
             match=r"Module 'missing_php_requirements' has no php_requirements defined in "
-            f"the plugins.module_utils.module_index.VERSION_MAP for given "
-            f"OPNsense version 'OPNsense Test'.",
+            "the plugins.module_utils.module_index.VERSION_MAP for given "
+            "OPNsense version 'OPNsense Test'.",
         ):
-            _ = new_config._get_php_requirements()
+            _val = new_config._get_php_requirements()
 
 
 def test_config_functions_must_be_present(sample_config_path):
@@ -196,10 +196,10 @@ def test_config_functions_must_be_present(sample_config_path):
         with pytest.raises(
             MissingConfigDefinitionForModuleError,
             match=r"Module 'missing_configure_functions' has no configure_functions defined in "
-            f"the plugins.module_utils.module_index.VERSION_MAP for given "
-            f"OPNsense version 'OPNsense Test'.",
+            "the plugins.module_utils.module_index.VERSION_MAP for given "
+            "OPNsense version 'OPNsense Test'.",
         ):
-            _ = new_config._get_configure_functions()
+            _val = new_config._get_configure_functions()
 
 
 def test_php_requirements_must_be_list(sample_config_path):
@@ -218,7 +218,7 @@ def test_php_requirements_must_be_list(sample_config_path):
             match=r"PHP requirements \(php_requirements\) for the module 'invalid_php_requirements' are "
             "not provided as a list in the VERSION_MAP using OPNsense version 'OPNsense Test'.",
         ):
-            _ = new_config._get_php_requirements()
+            _val = new_config._get_php_requirements()
 
 
 def test_configure_functions_must_be_dict(sample_config_path):
@@ -237,7 +237,7 @@ def test_configure_functions_must_be_dict(sample_config_path):
             match=r"Configure functions \(configure_functions\) for the module 'invalid_configure_functions' are "
             "not provided as a list in the VERSION_MAP using OPNsense version 'OPNsense Test'.",
         ):
-            _ = new_config._get_configure_functions()
+            _val = new_config._get_configure_functions()
 
 
 def test_get_php_requirements(sample_config_path):

--- a/tests/unit/plugins/module_utils/test_config_utils.py
+++ b/tests/unit/plugins/module_utils/test_config_utils.py
@@ -8,495 +8,351 @@ __metaclass__ = type
 
 import os
 from tempfile import NamedTemporaryFile
-from xml.etree import ElementTree
-from unittest.mock import patch, MagicMock, call
+from typing import List, Dict
+from unittest.mock import patch, MagicMock
+from xml.etree.ElementTree import Element
 
 import pytest
-from ansible_collections.puzzle.opnsense.plugins.module_utils import xml_utils
 from ansible_collections.puzzle.opnsense.plugins.module_utils.config_utils import (
-    OPNsenseConfig,
-    OPNSenseConfigUsageError,
+    OPNsenseModuleConfig,
+    UnsupportedOPNsenseVersion,
+    UnsupportedModuleSettingError,
+    ModuleMisconfigurationError,
+    MissingConfigDefinitionForModuleError,
+    UnsupportedVersionForModule,
 )
 
-VERSION_MAP = {
-    "OPNsense 22.7 (amd64/OpenSSL)": {
-        "system_settings": {
+# Test version map for OPNsense versions and modules
+TEST_VERSION_MAP = {
+    "OPNsense Test": {
+        "test_module": {
             "hostname": "system/hostname",
-            "domain": "system/domain",
-            # Add other mappings here.
-        }
-    },
-    "OPNsense 23.1": {
-        "system_settings": {
-            "hostname": "system/hostname",
-            "domain": "system/domain",
-            "php_requirements": [
-                "/usr/local/etc/inc/config.inc",
-                "/usr/local/etc/inc/util.inc",
-            ],
+            "php_requirements": ["req_1", "req_2"],
             "configure_functions": {
-                "system_timezone_configure": {
-                    "name": "system_timezone_configure",
-                    "configure_params": ["true"],
-                },
-                "plugins_configure": {
-                    "name": "plugins_configure",
-                    "configure_params": ["'dns'", "true"],
+                "test_configure_function": {
+                    "name": "test_configure_function",
+                    "configure_params": ["param_1"],
                 },
             },
-            # Add other mappings here.
         },
-        "test": "test1",
-        "interfaces": {
-            "wan": {"if": "interfaces/wan/if"},
-            # Add other mappings here.
+        "missing_php_requirements": {
+            "setting_1": "settings/one",
+            "setting_2": "settings/two",
+            # No php_requirements
+            "configure_functions": {},
         },
-    },
-    "OPNsense 1.0.0": {
-        "system_settings": {
-            "hostname": "system/hostname",
-            "domain": "system/domain",
-            # Add other mappings here.
+        "missing_configure_functions": {
+            "setting_1": "settings/one",
+            "setting_2": "settings/two",
+            # No configure_functions
+            "php_requirements": [],
+        },
+        "invalid_php_requirements": {
+            "setting_1": "settings/one",
+            "setting_2": "settings/two",
+            # No php_requirements and configure_functions
+            "php_requirements": "must be a list instead of a string",
+            "configure_functions": {
+                "test_configure_function": {
+                    "name": "test_configure_function",
+                    "configure_params": ["param_1"],
+                },
+            },
+        },
+        "invalid_configure_functions": {
+            "setting_1": "settings/one",
+            "setting_2": "settings/two",
+            # No php_requirements and configure_functions
+            "php_requirements": ["req_1", "req_2"],
+            "configure_functions": ["must", "be", "a", "dict"],
         },
     },
 }
 
+# Test XML configuration content
+TEST_XML: str = """<?xml version="1.0"?>
+    <opnsense>
+        <system>
+            <hostname>test_name</hostname>
+        </system>
+    </opnsense>
+    """
 
-@pytest.fixture(scope="module")
-def sample_config_path():
-    # Create a temporary file with sample config for testing
-    config_content = """<?xml version="1.0"?>
-<opnsense>
-    <system>
-        <optimization>normal</optimization>
-        <hostname>test_name</hostname>
-        <domain>test.domain.someplace</domain>
-    </system>
-    <interfaces>
-        <wan>
-            <if>vtnet0</if>
-        </wan>
-    </interfaces>
-    <test_key>test_value</test_key>
-    <test_nested_key_1>
-        <test_nested_key_2>test_value</test_nested_key_2>
-    </test_nested_key_1>
-    <new_key>
-        <new_nested_key></new_nested_key>
-    </new_key>
-</opnsense>"""
-    with NamedTemporaryFile(delete=False) as temp_file:
-        temp_file.write(config_content.encode())
-        temp_file.flush()
-        yield temp_file.name
+
+@pytest.fixture(scope="function")
+def sample_config_path(request):
+    """
+    Fixture that creates a temporary file with a test XML configuration.
+    The file  is used in the tests.
+
+    Returns:
+    - str: The path to the temporary file.
+    """
+    with patch(
+        "ansible_collections.puzzle.opnsense.plugins.module_utils.version_utils.get_opnsense_version",
+        return_value="OPNsense Test",
+    ), patch(
+        "ansible_collections.puzzle.opnsense.plugins.module_utils.module_index.VERSION_MAP",
+        TEST_VERSION_MAP,
+    ):
+        # Create a temporary file with a name based on the test function
+        with NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(TEST_XML.encode())
+            temp_file.flush()
+            yield temp_file.name
+
+    # Cleanup after the fixture is used
     os.unlink(temp_file.name)
-
-
-@pytest.fixture(scope="module")
-@patch(
-    "ansible_collections.puzzle.opnsense.plugins.module_utils.version_utils.get_opnsense_version",
-    return_value="OPNsense 23.1",
-)
-def opnsense_config(mock_object: MagicMock, sample_config_path):
-    with OPNsenseConfig(version_map=VERSION_MAP, path=sample_config_path) as config:
-        return config
-
-
-def test_get_item(opnsense_config):
-    """
-    Test retrieving a value from the config.
-
-    Given a sample OPNsense configuration file, the test verifies that a specific key-value pair
-    can be retrieved using the OPNsenseConfig object.
-
-    The expected behavior is that the retrieved value matches the original value in the config file.
-    """
-    assert opnsense_config["test_key"] == "test_value"
-    assert not opnsense_config.save()
-
-
-@patch(
-    "ansible_collections.puzzle.opnsense.plugins.module_utils.version_utils.get_opnsense_version",
-    return_value="OPNsense 23.1",
-)
-def test_set_item(mock_object: MagicMock, opnsense_config, sample_config_path):
-    """
-    Test setting a value in the config.
-
-    Given a sample OPNsense configuration file, the test verifies that a new key-value pair
-    can be added to the config using the OPNsenseConfig object.
-
-    The expected behavior is that the added key-value pair is present in the config
-    and the `save` method returns True indicating that the config has changed. When using
-    a new config context the changes are expected to persist.
-    """
-
-    opnsense_config["new_key"] = "new_value"
-    assert opnsense_config["new_key"] == "new_value"
-    assert opnsense_config.save()
-
-    with OPNsenseConfig(version_map=VERSION_MAP, path=sample_config_path) as new_config:
-        assert "new_key" in new_config
-        assert new_config["new_key"] == "new_value"
-
-
-@patch(
-    "ansible_collections.puzzle.opnsense.plugins.module_utils.version_utils.get_opnsense_version",
-    return_value="OPNsense 23.1",
-)
-def test_del_item(mock_object: MagicMock, opnsense_config, sample_config_path):
-    """
-    Test deleting a value from the config.
-
-    Given a sample OPNsense configuration file, the test verifies that a key-value pair
-    can be removed from the config using the `del` statement with the OPNsenseConfig object.
-
-    The expected behavior is that the deleted key is no longer present in the config,
-    the `changed` property is True indicating that the config has changed,
-    and the `save` method returns True indicating that the config has changed. When using
-    a new config context the changes are expected to persist.
-    """
-
-    del opnsense_config["test_key"]
-    assert "test_key" not in opnsense_config
-    assert opnsense_config.changed
-    assert opnsense_config.save()
-
-    with OPNsenseConfig(version_map=VERSION_MAP, path=sample_config_path) as new_config:
-        assert "test_key" not in new_config
-
-
-def test_contains(opnsense_config):
-    """
-    Test checking if a key exists in the config.
-
-    Given a sample OPNsense configuration file, the test verifies that the existence of a key
-    in the config can be checked using the `in` statement with the OPNsenseConfig object.
-
-    The expected behavior is that the test_key is found in the config,
-    and a non-existent key is not found.
-    """
-    assert "test_key" in opnsense_config
-    assert "nonexistent_key" not in opnsense_config
-    assert not opnsense_config.save()
-
-
-@patch(
-    "ansible_collections.puzzle.opnsense.plugins.module_utils.version_utils.get_opnsense_version",
-    return_value="OPNsense 23.1",
-)
-def test_save(mock_object: MagicMock, sample_config_path):
-    """
-    Test saving changes to the config.
-
-    Given a sample OPNsense configuration file, the test verifies that changes made to the config
-    using the OPNsenseConfig object can be saved.
-
-    The expected behavior is that the `save` method returns True when the config has changed,
-    indicating that the changes were successfully saved.
-    """
-
-    with OPNsenseConfig(version_map=VERSION_MAP, path=sample_config_path) as config:
-        config["test_key"] = "modified_value"
-        config["test_nested_key_1"]["test_nested_key_2"] = "modified_nested_value"
-        assert config.save()
-    # Reload the saved config and assert the changes were saved
-    reloaded_config = xml_utils.etree_to_dict(ElementTree.parse(sample_config_path).getroot())[
-        "opnsense"
-    ]
-    assert reloaded_config["test_key"] == "modified_value"
-    assert reloaded_config["test_nested_key_1"]["test_nested_key_2"] == "modified_nested_value"
-
-    with OPNsenseConfig(version_map=VERSION_MAP, path=sample_config_path) as new_config:
-        assert new_config["test_key"] == "modified_value"
-        assert new_config["test_nested_key_1"]["test_nested_key_2"] == "modified_nested_value"
-
-
-def test_changed(opnsense_config):
-    """
-    Test checking if the config has changed.
-
-    Given a sample OPNsense configuration file, the test verifies that the `changed` property
-    of the OPNsenseConfig object correctly indicates whether the config has changed.
-
-    The expected behavior is that the `changed` property is False initially, and True after making changes
-    to the config.
-    """
-
-    assert not opnsense_config.changed
-    opnsense_config["test_key"] = "modified_value"
-    assert opnsense_config.changed
-    opnsense_config.save()
-
-
-@patch(
-    "ansible_collections.puzzle.opnsense.plugins.module_utils.version_utils.get_opnsense_version",
-    return_value="OPNsense 23.1",
-)
-def test_exit_without_saving(mock_object: MagicMock, sample_config_path):
-    """
-    Test exiting the context without saving changes.
-
-    Given a sample OPNsense configuration file, the test verifies that when changes are made to the config
-    using the OPNsenseConfig object, attempting to exit the context without saving the changes raises a RuntimeError.
-
-    The expected behavior is that a RuntimeError is raised with the message "Config has changed. Cannot exit without saving."
-    """
-    with pytest.raises(RuntimeError, match="Config has changed. Cannot exit without saving."):
-        with OPNsenseConfig(version_map=VERSION_MAP, path=sample_config_path) as config:
-            config["test_key"] = "modified_value"
-            # The RuntimeError should be raised upon exiting the context without saving
-
-
-def test_get_nested_item(opnsense_config):
-    """
-    Test retrieving a nested value from the config.
-
-    Given a sample OPNsense configuration file, the test verifies that a specific nested key-value
-    pair can be retrieved using the OPNsenseConfig object.
-
-    The expected behavior is that the retrieved value matches the original value in the config file.
-    """
-
-    assert opnsense_config["test_nested_key_1"]["test_nested_key_2"] == "test_value"
-    assert not opnsense_config.save()
-
-
-@patch(
-    "ansible_collections.puzzle.opnsense.plugins.module_utils.version_utils.get_opnsense_version",
-    return_value="OPNsense 23.1",
-)
-def test_set_nested_item(mock_object: MagicMock, opnsense_config, sample_config_path):
-    """
-    Test setting a nested value in the config.
-
-    Given a sample OPNsense configuration file, the test verifies that a new nested key-value pair
-    can be added to the config using the OPNsenseConfig object.
-
-    The expected behavior is that the added key-value pair is present in the config
-    and the `save` method returns True indicating that the config has changed. When using
-    a new config context the changes are expected to persist.
-    """
-
-    opnsense_config["new_key"]["new_nested_key"] = "new_value"
-    assert opnsense_config["new_key"]["new_nested_key"] == "new_value"
-    assert opnsense_config.save()
-
-    with OPNsenseConfig(version_map=VERSION_MAP, path=sample_config_path) as new_config:
-        assert "new_key" in new_config
-        assert new_config["new_key"]["new_nested_key"] == "new_value"
-
-
-@patch(
-    "ansible_collections.puzzle.opnsense.plugins.module_utils.version_utils.get_opnsense_version",
-    return_value="OPNsense 23.1",
-)
-def test_del_nested_item(mock_object: MagicMock, opnsense_config, sample_config_path):
-    """
-    Test deleting a nested value from the config.
-
-    Given a sample OPNsense configuration file, the test verifies that a nested key-value pair
-    can be removed from the config using the `del` statement with the OPNsenseConfig object.
-
-    The expected behavior is that the deleted key is no longer present in the config,
-    the `changed` property is True indicating that the config has changed,
-    and the `save` method returns True indicating that the config has changed. When using
-    a new config context the changes are expected to persist.
-    """
-
-    del opnsense_config["test_nested_key_1"]["test_nested_key_2"]
-    assert "test_nested_key_2" not in opnsense_config["test_nested_key_1"]
-    assert opnsense_config.changed
-    assert opnsense_config.save()
-
-    with OPNsenseConfig(version_map=VERSION_MAP, path=sample_config_path) as new_config:
-        assert "test_nested_key_2" not in new_config
-
-
-def test_get_module_setting(opnsense_config):
-    """
-    Test retrieving module settings from the config.
-
-    Given a sample OPNsense configuration file, the test verifies that specific module settings
-    can be retrieved using the `get_module_setting` method of the OPNsenseConfig object.
-
-    The expected behavior is that the retrieved values for given module settings match
-    the original values in the config file. Additionally, the `save` method should return False
-    indicating that no changes to the config were made during the retrieval process.
-    """
-
-    assert (
-        opnsense_config.get_module_setting(module="system_settings", setting="hostname")
-        == "test_name"
-    )
-    assert (
-        opnsense_config.get_module_setting(module="system_settings", setting="domain")
-        == "test.domain.someplace"
-    )
-    assert opnsense_config.get_module_setting(module="interfaces", setting="if") == "vtnet0"
-    assert not opnsense_config.save()
-
-
-@patch(
-    "ansible_collections.puzzle.opnsense.plugins.module_utils.version_utils.get_opnsense_version",
-    return_value="OPNsense 23.1",
-)
-def test_set_module_setting(mock_object: MagicMock, opnsense_config, sample_config_path):
-    """
-    Test setting module settings in the config.
-
-    Given a sample OPNsense configuration file, the test verifies that module settings
-    can be modified using the `set_module_setting` method of the OPNsenseConfig object.
-
-    The expected behavior is that after setting the module settings, the `save` method returns True
-    indicating that the config has changed. When using a new config context, the changes are
-    expected to persist and the new values for the given settings should be reflected in the config.
-    """
-
-    opnsense_config.set_module_setting(
-        module="system_settings", setting="hostname", value="new_test_name"
-    )
-
-    opnsense_config.set_module_setting(
-        module="system_settings", setting="domain", value="new_test.domain.someplace"
-    )
-
-    assert opnsense_config.save()
-
-    with OPNsenseConfig(version_map=VERSION_MAP, path=sample_config_path) as new_config:
-        assert "system" in new_config
-        assert new_config["system"]["hostname"] == "new_test_name"
-        assert new_config["system"]["domain"] == "new_test.domain.someplace"
-
-
-@patch(
-    "ansible_collections.puzzle.opnsense.plugins.module_utils.version_utils.get_opnsense_version",
-    return_value="OPNsense 23.1",
-)
-def test_del_module_setting(mock_object: MagicMock, opnsense_config, sample_config_path):
-    """
-    Test deleting module settings from the config.
-
-    Given a sample OPNsense configuration file, the test verifies that module settings
-    can be removed using the `del_module_setting` method of the OPNsenseConfig object.
-
-    The expected behavior is that the settings are no longer present in the config
-    after deletion. The `changed` property is True, indicating that the config has been modified,
-    and the `save` method returns True, confirming that the changes have been saved.
-    When using a new config context, the changes should persist and the settings should
-    be absent from the config.
-    """
-
-    opnsense_config.del_module_setting(module="system_settings", setting="hostname")
-    opnsense_config.del_module_setting(module="system_settings", setting="domain")
-    assert opnsense_config.save()
-
-    with OPNsenseConfig(version_map=VERSION_MAP, path=sample_config_path) as new_config:
-        assert "system" in new_config
-        assert new_config["system"]["hostname"] is None
-        assert new_config["system"]["domain"] is None
-
-
-@patch("ansible_collections.puzzle.opnsense.plugins.module_utils.opnsense_utils.run_function")
-@patch(
-    "ansible_collections.puzzle.opnsense.plugins.module_utils.config_utils.OPNsenseConfig._get_configure_functions"
-)
-@patch(
-    "ansible_collections.puzzle.opnsense.plugins.module_utils.config_utils.OPNsenseConfig._get_php_requirements"
-)
-@patch(
-    "ansible_collections.puzzle.opnsense.plugins.module_utils.version_utils.get_opnsense_version",
-    return_value="OPNsense 23.1",
-)
-def test_apply_module_setting(
-    version_mock_object: MagicMock,
-    php_mock_object: MagicMock,
-    configure_mock_object: MagicMock,
-    run_function_mock_object: MagicMock,
-    opnsense_config,
-):
-    """
-    Test the application of module settings within the OPNsense configuration.
-
-    This test ensures that given a set of PHP requirements and configure functions,
-    the `apply_module_setting` method applies the settings correctly by invoking
-    the appropriate functions with the expected parameters.
-
-    The method under test should retrieve the PHP requirements and configuration
-    functions for the specified module and execute them, collecting the output.
-
-    We mock the dependencies involved in this process to assert that the functions
-    are called as expected, and the resultant output is correctly aggregated.
-
-    The expected behavior is that for each configure function provided, a corresponding
-    call to `opnsense_utils.run_function` is made with the appropriate PHP requirements
-    and parameters, and the result of these function calls is returned as a list of outputs.
-    """
-
-    test_php_requirements = [
-        "/usr/local/etc/inc/config.inc",
-        "/usr/local/etc/inc/util.inc",
-    ]
-
-    test_configure_functions = {
-        "system_timezone_configure": {
-            "name": "system_timezone_configure",
-            "configure_params": ["true"],
-        },
-        "plugins_configure": {
-            "name": "plugins_configure",
-            "configure_params": ["'dns'", "true"],
-        },
-    }
-
-    php_mock_object.return_value = test_php_requirements
-    configure_mock_object.return_value = test_configure_functions
-
-    # Act: Call the apply_module_setting method
-    result = opnsense_config.apply_module_setting(module="system_settings")
-
-    # Assert: Check that run_function was called correctly
-    expected_calls = [
-        call(
-            php_requirements=test_php_requirements,
-            configure_function="system_timezone_configure",
-            configure_params=["true"],
-        ),
-        call(
-            php_requirements=test_php_requirements,
-            configure_function="plugins_configure",
-            configure_params=["'dns'", "true"],
-        ),
-    ]
-    run_function_mock_object.assert_has_calls(expected_calls, any_order=True)
-    assert len(result) == len(test_configure_functions)
 
 
 @patch(
     "ansible_collections.puzzle.opnsense.plugins.module_utils.version_utils.get_opnsense_version",
     return_value="OPNsense X.X.X",
 )
-def test_version_not_found_in_version_map(
-    mock_object: MagicMock, opnsense_config, sample_config_path
+def test_unsupported_opnsense_version(
+    mocked_version_util: MagicMock, sample_config_path
 ):
     """
-    Test behavior when a non-existent version is accessed in the version map.
+    Test case to verify that an UnsupportedOPNsenseVersion exception is raised
+    when attempting to initialize OPNsenseModuleConfig with an unsupported OPNsense version.
 
-    This test patches the `get_opnsense_version` function to return a version string
-    that is not present in the version map. The purpose is to verify that the
-    `OPNsenseConfig` object raises the appropriate error when attempting to access
-    module settings associated with an undefined version.
-
-    The expected behavior is for a KeyError exception to be raised with a message
-    indicating that the specified version ("OPNsense X.X.X") was not found in the
-    version map. This confirms that the `OPNsenseConfig` object correctly handles
-    the situation where a configuration for a given version is requested but doesn't exist.
+    Args:
+    - mocked_version_util (MagicMock): A mock for version_utils.get_opnsense_version.
+    - sample_config_path (str): The path to the temporary test configuration file.
     """
-
     with pytest.raises(
-        OPNSenseConfigUsageError,
-        match="Version OPNsense X.X.X not supported in module system_settings",
+        UnsupportedOPNsenseVersion,
+        match=f"OPNsense version 'OPNsense X.X.X' not supported by puzzle.opnsense collection",
     ):
-        with OPNsenseConfig(version_map=VERSION_MAP, path=sample_config_path) as new_config:
-            new_config.get_module_setting(module="system_settings", setting="hostname")
-            # The RuntimeError should be raised upon accesing a version that not exists
+        _ = OPNsenseModuleConfig(module_name="test_module", path=sample_config_path)
+
+
+def test_unsupported_module(sample_config_path):
+    """
+    Test case to verify that an UnsupportedVersionForModule exception is raised
+    when attempting to initialize OPNsenseModuleConfig with an unsupported module.
+
+    Args:
+    - sample_config_path (str): The path to the temporary test configuration file.
+    """
+    with pytest.raises(
+        UnsupportedVersionForModule,
+        match=r"Module 'unsupported_module' not supported "
+        "for OPNsense version 'OPNsense Test'.",
+    ):
+        _ = OPNsenseModuleConfig(
+            module_name="unsupported_module", path=sample_config_path
+        )
+
+
+def test_unsupported_module_setting(sample_config_path):
+    """
+    Test case to verify that an UnsupportedModuleSettingError exception is raised
+    when attempting to retrieve an unsupported module setting.
+
+    Args:
+    - sample_config_path (str): The path to the temporary test configuration file.
+    """
+    with OPNsenseModuleConfig("test_module", path=sample_config_path) as new_config:
+        with pytest.raises(
+            UnsupportedModuleSettingError,
+            match="Setting 'unsupported' is not supported in module 'test_module' "
+            "for OPNsense version 'OPNsense Test'",
+        ):
+            _ = new_config.get_setting("unsupported")
+
+
+def test_php_requirements_must_be_present(sample_config_path):
+    """
+    Test case to verify that a MissingConfigDefinitionForModuleError exception is raised
+    when attempting to retrieve PHP requirements that are missing for a module.
+
+    Args:
+    - sample_config_path (str): The path to the temporary test configuration file.
+    """
+    with OPNsenseModuleConfig(
+        module_name="missing_php_requirements", path=sample_config_path
+    ) as new_config:
+        with pytest.raises(
+            MissingConfigDefinitionForModuleError,
+            match=r"Module 'missing_php_requirements' has no php_requirements defined in "
+            f"the plugins.module_utils.module_index.VERSION_MAP for given "
+            f"OPNsense version 'OPNsense Test'.",
+        ):
+            _ = new_config._get_php_requirements()
+
+
+def test_config_functions_must_be_present(sample_config_path):
+    """
+    Test case to verify that a MissingConfigDefinitionForModuleError exception is raised
+    when attempting to retrieve configure functions that are missing for a module.
+
+    Args:
+    - sample_config_path (str): The path to the temporary test configuration file.
+    """
+    with OPNsenseModuleConfig(
+        module_name="missing_configure_functions", path=sample_config_path
+    ) as new_config:
+        with pytest.raises(
+            MissingConfigDefinitionForModuleError,
+            match=r"Module 'missing_configure_functions' has no configure_functions defined in "
+            f"the plugins.module_utils.module_index.VERSION_MAP for given "
+            f"OPNsense version 'OPNsense Test'.",
+        ):
+            _ = new_config._get_configure_functions()
+
+
+def test_php_requirements_must_be_list(sample_config_path):
+    """
+    Test case to verify that a ModuleMisconfigurationError exception is raised
+    when PHP requirements are not provided as a list.
+
+    Args:
+    - sample_config_path (str): The path to the temporary test configuration file.
+    """
+    with OPNsenseModuleConfig(
+        module_name="invalid_php_requirements", path=sample_config_path
+    ) as new_config:
+        with pytest.raises(
+            ModuleMisconfigurationError,
+            match=r"PHP requirements \(php_requirements\) for the module 'invalid_php_requirements' are "
+            "not provided as a list in the VERSION_MAP using OPNsense version 'OPNsense Test'.",
+        ):
+            _ = new_config._get_php_requirements()
+
+
+def test_configure_functions_must_be_dict(sample_config_path):
+    """
+    Test case to verify that a ModuleMisconfigurationError exception is raised
+    when configure functions are not provided as a dictionary.
+
+    Args:
+    - sample_config_path (str): The path to the temporary test configuration file.
+    """
+    with OPNsenseModuleConfig(
+        module_name="invalid_configure_functions", path=sample_config_path
+    ) as new_config:
+        with pytest.raises(
+            ModuleMisconfigurationError,
+            match=r"Configure functions \(configure_functions\) for the module 'invalid_configure_functions' are "
+            "not provided as a list in the VERSION_MAP using OPNsense version 'OPNsense Test'.",
+        ):
+            _ = new_config._get_configure_functions()
+
+
+def test_get_php_requirements(sample_config_path):
+    """
+    Test case to verify the correct retrieval of PHP requirements for a module.
+
+    Args:
+    - sample_config_path (str): The path to the temporary test configuration file.
+    """
+    with OPNsenseModuleConfig(
+        module_name="test_module", path=sample_config_path
+    ) as new_config:
+
+        requirements: List[str] = new_config._get_php_requirements()
+
+        assert (
+            requirements
+            == TEST_VERSION_MAP["OPNsense Test"]["test_module"]["php_requirements"]
+        )
+
+
+def test_get_configure_functions(sample_config_path):
+    """
+    Test case to verify the correct retrieval of configure functions for a module.
+
+    Args:
+    - sample_config_path (str): The path to the temporary test configuration file.
+    """
+    with OPNsenseModuleConfig(
+        module_name="test_module", path=sample_config_path
+    ) as new_config:
+
+        requirements: Dict = new_config._get_configure_functions()
+
+        assert (
+            requirements
+            == TEST_VERSION_MAP["OPNsense Test"]["test_module"]["configure_functions"]
+        )
+
+
+def test_changed(sample_config_path):
+    """
+    Test case to verify that the `changed` property correctly identifies changes
+    in the OPNsense configuration.
+
+    Args:
+    - sample_config_path (str): The path to the temporary test configuration file.
+    """
+    with OPNsenseModuleConfig("test_module", path=sample_config_path) as new_config:
+        new_config.set_module_setting(value="testtest", setting="hostname")
+        assert new_config.changed
+        new_config.save()
+
+
+def test_get_setting(sample_config_path):
+    """
+    Test case to verify the correct retrieval of a specific setting from the OPNsense configuration.
+
+    Args:
+    - sample_config_path (str): The path to the temporary test configuration file.
+    """
+    with OPNsenseModuleConfig("test_module", path=sample_config_path) as new_config:
+        hostname_setting: Element = new_config.get_setting("hostname")
+        assert isinstance(hostname_setting, Element)
+        assert "test_name" == hostname_setting.text
+        new_config.save()
+
+
+def test_save_on_changed(sample_config_path):
+    """
+    Test case to verify that the configuration is saved when changes are made.
+
+    Args:
+    - sample_config_path (str): The path to the temporary test configuration file.
+    """
+    with OPNsenseModuleConfig("test_module", path=sample_config_path) as new_config:
+        new_config.set_module_setting(value="testtest", setting="hostname")
+        assert new_config.save()
+
+
+def test_save_on_not_changed(sample_config_path):
+    """
+    Test case to verify that the configuration is not saved when no changes are made.
+
+    Args:
+    - sample_config_path (str): The path to the temporary test configuration file.
+    """
+    with OPNsenseModuleConfig("test_module", path=sample_config_path) as new_config:
+        assert not new_config.save()
+
+
+def test_diff_on_change(sample_config_path):
+    """
+    Test case to verify that the `diff` property correctly identifies changes
+    in the OPNsense configuration.
+
+    Args:
+    - sample_config_path (str): The path to the temporary test configuration file.
+    """
+    with OPNsenseModuleConfig("test_module", path=sample_config_path) as new_config:
+        new_config.set_module_setting(value="testtest", setting="hostname")
+        diff = new_config.diff
+
+        assert diff == {"hostname": "testtest"}
+        new_config.save()
+
+
+def test_diff_on_no_change(sample_config_path):
+    """
+    Test case to verify that the `diff` property correctly identifies no changes
+    in the OPNsense configuration.
+
+    Args:
+    - sample_config_path (str): The path to the temporary test configuration file.
+    """
+    with OPNsenseModuleConfig("test_module", path=sample_config_path) as new_config:
+        diff = new_config.diff
+        assert diff == {}


### PR DESCRIPTION
Since we intend to access module settings using XPaths, it no longer makes sense to use the translation layer from XML to dict. These changes refactor the `OPNsenseConfig` to use ElementTree directly. Since we also now use a version aware approach the `OPNsenseConfig` is now also scoped to module specific settings and therefore has been renamed to `OPNsenseModuleConfig`. 

See the changes to the docsite for usage examples of the refactored class.