### PR TITLE
Module config uses confg contexts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test-unit:
 
 # runs a little faster because only one version is checked
 test-unit-dev:
-	pipenv run ansible-test units --coverage --python 3.10
+	pipenv run ansible-test units --coverage --python 3.11
 
 test-sanity:
 	pipenv run ansible-test sanity --docker
@@ -26,3 +26,12 @@ test-molecule:
 	pipenv run molecule test --all
 
 test: test-sanity test-unit test-coverage-report test-molecule
+
+
+local:
+	find plugins -type f -name "*.py" -exec sed -i 's/ansible_collections\.puzzle\.opnsense\.plugins\./plugins\./g' {} +
+	find tests -type f -name "*.py" -exec sed -i 's/ansible_collections\.puzzle\.opnsense\.plugins\./plugins\./g' {} +
+
+ansible:
+	find plugins -type f -name "*.py" -exec sed -i 's/plugins\./ansible_collections\.puzzle\.opnsense\.plugins\./g' {} +
+	find tests -type f -name "*.py" -exec sed -i 's/plugins\./ansible_collections\.puzzle\.opnsense\.plugins\./g' {} +

--- a/docs/docsite/rst/development_guide.rst
+++ b/docs/docsite/rst/development_guide.rst
@@ -126,9 +126,9 @@ Structure of VERSION_MAP
 
 - Top-Level Keys: Each top-level key represents a specific version of OPNsense, such as "OPNsense 22.7 (amd64/OpenSSL)".
 
-- Module Configuration: The value associated with each OPNsense version key is a dictionary. This dictionary maps module names to their specific configuration settings.
+- Config Context: Config context define a reusable context for modules to be consumed. They scope settings, configure functions and php requirements to single use cases. An Ansible Module can use one or multiple config contexts to access XML-Settings or php functions.
 
-- Configuration Details: For each module, the configuration includes:
+- Configuration Details: For each config context, the configuration includes:
 
   - **Setting Mappings**: Key-value pairs where the key represents a configuration setting (e.g., 'hostname') and the value is its corresponding XPath in the OPNsense configuration file.
 

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -354,8 +354,7 @@ class OPNsenseModuleConfig:
                 )
             else:
                 result_dict = {
-                    "check_mode":
-                        "Ansible running in check mode, does not execute configure functions",
+                    "check_mode": "Ansible running in check mode, does not execute configure functions",
                     "rc": 0,
                 }
             cmd_output.append({**meta_dict, **result_dict})

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -199,9 +199,9 @@ class OPNsenseModuleConfig:
         Returns:
         - Element: The retrieved setting element.
         """
-        for config_key, config_map in self._config_maps.items():
-            if setting_name in config_map:
-                return self._config_xml_tree.find(config_map[setting_name])
+        for cfg_map in self._config_maps.values():
+            if setting_name in cfg_map:
+                return self._config_xml_tree.find(cfg_map[setting_name])
 
         supported_settings: List[str] = []
         for cfg_map in self._config_maps.values():
@@ -227,8 +227,8 @@ class OPNsenseModuleConfig:
 
         all_php_requirements: list = []
 
-        for config_map in self._config_maps.values():
-            php_requirements: Optional[list] = config_map.get("php_requirements")
+        for cfg_map in self._config_maps.values():
+            php_requirements: Optional[list] = cfg_map.get("php_requirements")
 
             # enforce presence of php_requirements in the VERSION_MAP
             if php_requirements is None:
@@ -281,8 +281,8 @@ class OPNsenseModuleConfig:
 
         all_configure_functions: dict = {}
 
-        for config_map in self._config_maps.values():
-            configure_functions: Optional[dict] = config_map.get("configure_functions")
+        for cfg_map in self._config_maps.values():
+            configure_functions: Optional[dict] = cfg_map.get("configure_functions")
 
             # enforce presence of configure_functions in the VERSION_MAP
             if configure_functions is None:
@@ -354,7 +354,8 @@ class OPNsenseModuleConfig:
                 )
             else:
                 result_dict = {
-                    "check_mode": "Ansible running in check mode, does not execute configure functions",
+                    "check_mode":
+                        "Ansible running in check mode, does not execute configure functions",
                     "rc": 0,
                 }
             cmd_output.append({**meta_dict, **result_dict})
@@ -390,7 +391,7 @@ class OPNsenseModuleConfig:
 
         # get xpath from key_mapping
         xpath: Optional[str] = None
-        for cfg_key, cfg_map in self._config_maps.items():
+        for cfg_map in self._config_maps.values():
             if setting in cfg_map:
                 xpath = cfg_map.get(setting)
 
@@ -433,6 +434,8 @@ class OPNsenseModuleConfig:
                 # Find the setting in the file-based configuration
                 config_diff_before.update({xpath: file_config.find(xpath).text})
                 # Find the setting in the in-memory configuration
-                config_diff_after.update({xpath: self._config_xml_tree.find(xpath).text})
+                config_diff_after.update(
+                    {xpath: self._config_xml_tree.find(xpath).text}
+                )
 
         return {"before": config_diff_before, "after": config_diff_after}

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -73,7 +73,8 @@ class OPNsenseModuleConfig:
     Attributes:
         _config_xml_tree (Element): The XML tree of the configuration file.
         _config_path (str): The file path of the configuration.
-        _config_map (dict): The mapping of settings and their XPath in the XML tree.
+        _config_maps (dict): The mappings of settings and their XPath in the XML tree.
+        _config_contexts (dict): List of required config_contexts
         _module_name (str): The name of the module.
         _opnsense_version (str): The OPNsense version.
         _check_mode (bool): If the module is run in check_mode or not
@@ -81,13 +82,18 @@ class OPNsenseModuleConfig:
 
     _config_xml_tree: Element
     _config_path: str
-    _config_map: dict
     _module_name: str
+    _config_maps: Dict[str, dict] = {}
+    _config_contexts: List[str]
     _opnsense_version: str
     _check_mode: bool
 
     def __init__(
-        self, module_name: str, check_mode: bool, path: str = "/conf/config.xml"
+        self,
+        module_name: str,
+        config_context_names: List[str],
+        path: str = "/conf/config.xml",
+        check_mode: bool = False,
     ):
         """
         Initializes the OPNsenseModuleConfig class.
@@ -98,26 +104,28 @@ class OPNsenseModuleConfig:
             path (str, optional): The path to the config.xml file. Defaults to "/conf/config.xml".
         """
         self._module_name = module_name
+        self._config_contexts = config_context_names
         self._config_path = path
         self._config_xml_tree = self._load_config()
         self._opnsense_version = version_utils.get_opnsense_version()
         self._check_mode = check_mode
-
         try:
             version_map: dict = module_index.VERSION_MAP[self._opnsense_version]
         except KeyError as ke:
             raise UnsupportedOPNsenseVersion(
                 f"OPNsense version '{self._opnsense_version}' not supported "
-                "by puzzle.opnsense collection"
+                "by puzzle.opnsense collection.\n"
+                f"Supported versions are {list(module_index.VERSION_MAP.keys())}"
             ) from ke
+        for config_context_name in config_context_names:
+            if config_context_name not in version_map:
+                raise UnsupportedVersionForModule(
+                    f"Config context '{config_context_name}' not supported "
+                    f"for OPNsense version '{self._opnsense_version}'.\n"
+                    f"Supported config contexts are {list(version_map.keys())}"
+                )
 
-        if self._module_name not in version_map:
-            raise UnsupportedVersionForModule(
-                f"Module '{self._module_name}' not supported "
-                f"for OPNsense version '{self._opnsense_version}'."
-            )
-
-        self._config_map = version_map[self._module_name]
+            self._config_maps[config_context_name] = version_map[config_context_name]
 
     def _load_config(self) -> Element:
         """
@@ -191,12 +199,18 @@ class OPNsenseModuleConfig:
         Returns:
         - Element: The retrieved setting element.
         """
-        if setting_name not in self._config_map:
-            raise UnsupportedModuleSettingError(
-                f"Setting '{setting_name}' is not supported in module '{self._module_name}' "
-                f"for OPNsense version '{self._opnsense_version}'"
-            )
-        return self._config_xml_tree.find(self._config_map[setting_name])
+        for config_key, config_map in self._config_maps.items():
+            if setting_name in config_map:
+                return self._config_xml_tree.find(config_map[setting_name])
+
+        supported_settings: List[str] = []
+        for cfg_map in self._config_maps.values():
+            supported_settings.extend(cfg_map.keys())
+        raise UnsupportedModuleSettingError(
+            f"Setting '{setting_name}' is not supported in module '{self._module_name}' "
+            f"for OPNsense version '{self._opnsense_version}'."
+            f"Supported settings are {supported_settings}"
+        )
 
     def _get_php_requirements(self) -> list:
         """
@@ -211,26 +225,30 @@ class OPNsenseModuleConfig:
         - ModuleMisconfigurationError: If PHP requirements are not in list format.
         """
 
-        php_requirements: Optional[list] = self._config_map.get("php_requirements")
+        all_php_requirements: list = []
 
-        # enforce presence of php_requirements in the VERSION_MAP
-        if php_requirements is None:
-            raise MissingConfigDefinitionForModuleError(
-                f"Module '{self._module_name}' has no php_requirements defined in "
-                f"the plugins.module_utils.module_index.VERSION_MAP for given "
-                f"OPNsense version '{self._opnsense_version}'."
-            )
+        for config_map in self._config_maps.values():
+            php_requirements: Optional[list] = config_map.get("php_requirements")
 
-        # ensure php_requirements are defined as a list
-        if not isinstance(php_requirements, list):
-            raise ModuleMisconfigurationError(
-                f"PHP requirements (php_requirements) for the module '{self._module_name}' are "
-                "not provided as a list in the VERSION_MAP using OPNsense version"
-                f"'{self._opnsense_version}'."
-            )
+            # enforce presence of php_requirements in the VERSION_MAP
+            if php_requirements is None:
+                raise MissingConfigDefinitionForModuleError(
+                    f"Module '{self._module_name}' has no php_requirements defined in "
+                    f"the plugins.module_utils.module_index.VERSION_MAP for given "
+                    f"OPNsense version '{self._opnsense_version}'."
+                )
 
-        # return list
-        return php_requirements
+            # ensure php_requirements are defined as a list
+            if not isinstance(php_requirements, list):
+                raise ModuleMisconfigurationError(
+                    f"PHP requirements (php_requirements) for the module '{self._module_name}' are "
+                    "not provided as a list in the VERSION_MAP using OPNsense version"
+                    f"'{self._opnsense_version}'."
+                )
+
+            all_php_requirements.extend(php_requirements)
+
+        return all_php_requirements
 
     def _get_configure_functions(self) -> dict:
         """
@@ -261,31 +279,33 @@ class OPNsenseModuleConfig:
             Functionality depends on accurate and complete version_map.
         """
 
-        configure_functions: Optional[dict] = self._config_map.get(
-            "configure_functions"
-        )
+        all_configure_functions: dict = {}
 
-        # enforce presence of configure_functions in the VERSION_MAP
-        if configure_functions is None:
-            raise MissingConfigDefinitionForModuleError(
-                f"Module '{self._module_name}' has no configure_functions defined in "
-                f"the plugins.module_utils.module_index.VERSION_MAP for given "
-                f"OPNsense version '{self._opnsense_version}'."
-            )
+        for config_map in self._config_maps.values():
+            configure_functions: Optional[dict] = config_map.get("configure_functions")
 
-        # ensure configure_functions are defined as a list
-        if not isinstance(configure_functions, dict):
-            raise ModuleMisconfigurationError(
-                "Configure functions (configure_functions) for the module "
-                f"'{self._module_name}' are "
-                "not provided as a list in the VERSION_MAP using OPNsense version "
-                f"'{self._opnsense_version}'."
-            )
+            # enforce presence of configure_functions in the VERSION_MAP
+            if configure_functions is None:
+                raise MissingConfigDefinitionForModuleError(
+                    f"Module '{self._module_name}' has no configure_functions defined in "
+                    f"the plugins.module_utils.module_index.VERSION_MAP for given "
+                    f"OPNsense version '{self._opnsense_version}'."
+                )
 
-        # return list
-        return configure_functions
+            # ensure configure_functions are defined as a list
+            if not isinstance(configure_functions, dict):
+                raise ModuleMisconfigurationError(
+                    "Configure functions (configure_functions) for the module "
+                    f"'{self._module_name}' are "
+                    "not provided as a list in the VERSION_MAP using OPNsense version "
+                    f"'{self._opnsense_version}'."
+                )
 
-    def apply_settings(self) -> List[str]:
+            all_configure_functions.update(configure_functions)
+
+        return all_configure_functions
+
+    def apply_settings(self) -> List[dict]:
         """
         Retrieves and applies configuration-specific PHP requirements and configure functions for
         a given module.
@@ -326,11 +346,17 @@ class OPNsenseModuleConfig:
         # run configure functions with all required php dependencies and store their output.
         for value in configure_functions.values():
             meta_dict = {"function": value["name"], "params": value["configure_params"]}
-            result_dict = opnsense_utils.run_function(
-                php_requirements=php_requirements,
-                configure_function=value["name"],
-                configure_params=value["configure_params"],
-            )
+            if not self._check_mode:
+                result_dict = opnsense_utils.run_function(
+                    php_requirements=php_requirements,
+                    configure_function=value["name"],
+                    configure_params=value["configure_params"],
+                )
+            else:
+                result_dict = {
+                    "check_mode": "Ansible running in check mode, does not execute configure functions",
+                    "rc": 0,
+                }
             cmd_output.append({**meta_dict, **result_dict})
 
         return cmd_output
@@ -363,8 +389,15 @@ class OPNsenseModuleConfig:
         """
 
         # get xpath from key_mapping
-        xpath = self._config_map.get(setting)
+        xpath: Optional[str] = None
+        for cfg_key, cfg_map in self._config_maps.items():
+            if setting in cfg_map:
+                xpath = cfg_map.get(setting)
 
+        if xpath is None:
+            raise ModuleMisconfigurationError(
+                f"Could not access given setting {setting}"
+            )
         # create a copy of the _config_dict
         _setting: Element = self._config_xml_tree.find(xpath)
 
@@ -392,14 +425,14 @@ class OPNsenseModuleConfig:
         # Create a dictionary to store the differences
         config_diff_before = {}
         config_diff_after = {}
+        for cfg_map in self._config_maps.values():
+            for setting_name, xpath in cfg_map.items():
+                if setting_name in ["php_requirements", "configure_functions"]:
+                    continue
 
-        for setting_name, xpath in self._config_map.items():
-            if setting_name in ["php_requirements", "configure_functions"]:
-                continue
-
-            # Find the setting in the file-based configuration
-            config_diff_before.update({xpath: file_config.find(xpath).text})
-            # Find the setting in the in-memory configuration
-            config_diff_after.update({xpath: self._config_xml_tree.find(xpath).text})
+                # Find the setting in the file-based configuration
+                config_diff_before.update({xpath: file_config.find(xpath).text})
+                # Find the setting in the in-memory configuration
+                config_diff_after.update({xpath: self._config_xml_tree.find(xpath).text})
 
         return {"before": config_diff_before, "after": config_diff_after}

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -73,7 +73,7 @@ class OPNsenseModuleConfig:
     Attributes:
         _config_xml_tree (Element): The XML tree of the configuration file.
         _config_path (str): The file path of the configuration.
-        _config_maps (dict): The mappings of settings and their XPath in the XML tree.
+        _config_maps (List[str]): The mappings of settings and their XPath in the XML tree.
         _config_contexts (dict): List of required config_contexts
         _module_name (str): The name of the module.
         _opnsense_version (str): The OPNsense version.

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -31,15 +31,15 @@ class OPNSenseConfigUsageError(Exception):
 class MissingConfigDefinitionForModuleError(Exception):
     """
     Exception raised when a required config definition is missing for a module in the
-    plugins.module_utils.module_index.VERSION_MAP. Required configs must include
-    'php_requirements' and 'configure_functions'.
+    ansible_collections.puzzle.opnsense.plugins.module_utils.module_index.VERSION_MAP.
+    Required configs must include 'php_requirements' and 'configure_functions'.
     """
 
 
 class ModuleMisconfigurationError(Exception):
     """
     Exception raised when module configurations are not in the expected format as defined in the
-    plugins.module_utils.module_index.VERSION_MAP.
+    ansible_collections.puzzle.opnsense.plugins.module_utils.module_index.VERSION_MAP.
     """
 
 
@@ -234,7 +234,7 @@ class OPNsenseModuleConfig:
             if php_requirements is None:
                 raise MissingConfigDefinitionForModuleError(
                     f"Module '{self._module_name}' has no php_requirements defined in "
-                    f"the plugins.module_utils.module_index.VERSION_MAP for given "
+                    f"the ansible_collections.puzzle.opnsense.plugins.module_utils.module_index.VERSION_MAP for given "  # pylint: disable=line-too-long
                     f"OPNsense version '{self._opnsense_version}'."
                 )
 
@@ -288,7 +288,7 @@ class OPNsenseModuleConfig:
             if configure_functions is None:
                 raise MissingConfigDefinitionForModuleError(
                     f"Module '{self._module_name}' has no configure_functions defined in "
-                    f"the plugins.module_utils.module_index.VERSION_MAP for given "
+                    f"the ansible_collections.puzzle.opnsense.plugins.module_utils.module_index.VERSION_MAP for given "  # pylint: disable=line-too-long
                     f"OPNsense version '{self._opnsense_version}'."
                 )
 
@@ -354,7 +354,7 @@ class OPNsenseModuleConfig:
                 )
             else:
                 result_dict = {
-                    "check_mode": "Ansible running in check mode, does not execute configure functions",
+                    "check_mode": "Ansible running in check mode, does not execute configure functions",  # pylint: disable=line-too-long
                     "rc": 0,
                 }
             cmd_output.append({**meta_dict, **result_dict})

--- a/plugins/modules/system_settings_general.py
+++ b/plugins/modules/system_settings_general.py
@@ -166,7 +166,9 @@ def main():
     timezone_param = module.params.get("timezone")
 
     with OPNsenseModuleConfig(
-        module_name="system_settings_general", check_mode=module.check_mode
+        module_name="system_settings_general",
+        config_context_names=["system_settings_general"],
+        check_mode=module.check_mode,
     ) as config:
         if hostname_param:
             if not is_hostname(hostname_param):

--- a/tests/unit/plugins/module_utils/test_config_utils.py
+++ b/tests/unit/plugins/module_utils/test_config_utils.py
@@ -38,6 +38,16 @@ TEST_VERSION_MAP = {
                 },
             },
         },
+        "test_module_2": {
+            "timezone": "system/timezone",
+            "php_requirements": ["req_1", "req_2"],
+            "configure_functions": {
+                "test_configure_function": {
+                    "name": "test_configure_function",
+                    "configure_params": ["param_1"],
+                },
+            },
+        },
         "missing_php_requirements": {
             "setting_1": "settings/one",
             "setting_2": "settings/two",
@@ -77,6 +87,7 @@ TEST_XML: str = """<?xml version="1.0"?>
     <opnsense>
         <system>
             <hostname>test_name</hostname>
+            <timezone>test_timezone</timezone>
         </system>
     </opnsense>
     """
@@ -173,6 +184,26 @@ def test_unsupported_module_setting(sample_config_path):
             "for OPNsense version 'OPNsense Test'",
         ):
             _val = new_config.get("unsupported")
+
+
+def test_setting_from_two_contexts_accessible(sample_config_path):
+    """
+    Test case to verify that an UnsupportedModuleSettingError exception is raised
+    when attempting to retrieve an unsupported module setting.
+
+    Args:
+    - sample_config_path (str): The path to the temporary test configuration file.
+    """
+    with OPNsenseModuleConfig(
+        "test_module",
+        config_context_names=["test_module", "test_module_2"],
+        path=sample_config_path,
+    ) as new_config:
+        hostname = new_config.get("hostname")
+        timezone = new_config.get("timezone")
+
+        assert hostname.text == "test_name"
+        assert timezone.text == "test_timezone"
 
 
 def test_php_requirements_must_be_present(sample_config_path):

--- a/tests/unit/plugins/module_utils/test_config_utils.py
+++ b/tests/unit/plugins/module_utils/test_config_utils.py
@@ -188,8 +188,8 @@ def test_unsupported_module_setting(sample_config_path):
 
 def test_setting_from_two_contexts_accessible(sample_config_path):
     """
-    Test case to verify that an UnsupportedModuleSettingError exception is raised
-    when attempting to retrieve an unsupported module setting.
+    Test case to verify that a OPNsenseModuleConfig with multiple context can access
+    settings of any given context.
 
     Args:
     - sample_config_path (str): The path to the temporary test configuration file.

--- a/tests/unit/plugins/module_utils/test_config_utils.py
+++ b/tests/unit/plugins/module_utils/test_config_utils.py
@@ -1,6 +1,6 @@
 # Copyright: (c) 2023, Puzzle ITC
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-"""Tests for the plugins.module_utils.config_utils module."""
+"""Tests for the ansible_collections.puzzle.opnsense.plugins.module_utils.config_utils module."""
 
 # This is probably intentional and required for the fixture
 # pylint: disable=redefined-outer-name,unused-argument,protected-access
@@ -206,6 +206,27 @@ def test_setting_from_two_contexts_accessible(sample_config_path):
         assert timezone.text == "test_timezone"
 
 
+def test_setting_from_another_context_raises_error(sample_config_path):
+    """
+    Test case to verify that a OPNsenseModuleConfig with multiple context cannot access
+    a context it has not been initialized with.
+
+    Args:
+    - sample_config_path (str): The path to the temporary test configuration file.
+    """
+    with OPNsenseModuleConfig(
+        "test_module",
+        config_context_names=["test_module"],
+        path=sample_config_path,
+    ) as new_config:
+        with pytest.raises(
+            UnsupportedModuleSettingError,
+            match="Setting 'timezone' is not supported in module 'test_module' "
+            "for OPNsense version 'OPNsense Test'",
+        ):
+            _timezone = new_config.get("timezone")
+
+
 def test_php_requirements_must_be_present(sample_config_path):
     """
     Test case to verify that a MissingConfigDefinitionForModuleError exception is raised
@@ -223,7 +244,7 @@ def test_php_requirements_must_be_present(sample_config_path):
         with pytest.raises(
             MissingConfigDefinitionForModuleError,
             match=r"Module 'missing_php_requirements' has no php_requirements defined in "
-            "the plugins.module_utils.module_index.VERSION_MAP for given "
+            "the ansible_collections.puzzle.opnsense.plugins.module_utils.module_index.VERSION_MAP for given "  # pylint: disable=line-too-long
             "OPNsense version 'OPNsense Test'.",
         ):
             _val = new_config._get_php_requirements()
@@ -246,7 +267,7 @@ def test_config_functions_must_be_present(sample_config_path):
         with pytest.raises(
             MissingConfigDefinitionForModuleError,
             match=r"Module 'missing_configure_functions' has no configure_functions defined in "
-            "the plugins.module_utils.module_index.VERSION_MAP for given "
+            "the ansible_collections.puzzle.opnsense.plugins.module_utils.module_index.VERSION_MAP for given "  # pylint: disable=line-too-long
             "OPNsense version 'OPNsense Test'.",
         ):
             _val = new_config._get_configure_functions()

--- a/tests/unit/plugins/module_utils/test_config_utils.py
+++ b/tests/unit/plugins/module_utils/test_config_utils.py
@@ -128,7 +128,10 @@ def test_unsupported_opnsense_version(
         match="OPNsense version 'OPNsense X.X.X' not supported by puzzle.opnsense collection",
     ):
         _val = OPNsenseModuleConfig(
-            module_name="test_module", check_mode=False, path=sample_config_path
+            module_name="test_module",
+            config_context_names=["test_module"],
+            path=sample_config_path,
+            check_mode=False,
         )
 
 
@@ -142,11 +145,14 @@ def test_unsupported_module(sample_config_path):
     """
     with pytest.raises(
         UnsupportedVersionForModule,
-        match=r"Module 'unsupported_module' not supported "
+        match=r"Config context 'unsupported_module' not supported "
         "for OPNsense version 'OPNsense Test'.",
     ):
         _val = OPNsenseModuleConfig(
-            module_name="unsupported_module", check_mode=False, path=sample_config_path
+            module_name="unsupported_module",
+            config_context_names=["unsupported_module"],
+            path=sample_config_path,
+            check_mode=False,
         )
 
 
@@ -159,7 +165,7 @@ def test_unsupported_module_setting(sample_config_path):
     - sample_config_path (str): The path to the temporary test configuration file.
     """
     with OPNsenseModuleConfig(
-        "test_module", check_mode=False, path=sample_config_path
+        "test_module", config_context_names=["test_module"], path=sample_config_path
     ) as new_config:
         with pytest.raises(
             UnsupportedModuleSettingError,
@@ -179,8 +185,9 @@ def test_php_requirements_must_be_present(sample_config_path):
     """
     with OPNsenseModuleConfig(
         module_name="missing_php_requirements",
-        check_mode=False,
+        config_context_names=["missing_php_requirements"],
         path=sample_config_path,
+        check_mode=False,
     ) as new_config:
         with pytest.raises(
             MissingConfigDefinitionForModuleError,
@@ -201,8 +208,9 @@ def test_config_functions_must_be_present(sample_config_path):
     """
     with OPNsenseModuleConfig(
         module_name="missing_configure_functions",
-        check_mode=False,
+        config_context_names=["missing_configure_functions"],
         path=sample_config_path,
+        check_mode=False,
     ) as new_config:
         with pytest.raises(
             MissingConfigDefinitionForModuleError,
@@ -223,8 +231,9 @@ def test_php_requirements_must_be_list(sample_config_path):
     """
     with OPNsenseModuleConfig(
         module_name="invalid_php_requirements",
-        check_mode=False,
+        config_context_names=["invalid_php_requirements"],
         path=sample_config_path,
+        check_mode=False,
     ) as new_config:
         with pytest.raises(
             ModuleMisconfigurationError,
@@ -247,8 +256,9 @@ def test_configure_functions_must_be_dict(sample_config_path):
     """
     with OPNsenseModuleConfig(
         module_name="invalid_configure_functions",
-        check_mode=False,
+        config_context_names=["invalid_configure_functions"],
         path=sample_config_path,
+        check_mode=False,
     ) as new_config:
         with pytest.raises(
             ModuleMisconfigurationError,
@@ -270,7 +280,10 @@ def test_get_php_requirements(sample_config_path):
     - sample_config_path (str): The path to the temporary test configuration file.
     """
     with OPNsenseModuleConfig(
-        module_name="test_module", check_mode=False, path=sample_config_path
+        module_name="test_module",
+        config_context_names=["test_module"],
+        path=sample_config_path,
+        check_mode=False,
     ) as new_config:
         requirements: List[str] = new_config._get_php_requirements()
 
@@ -288,7 +301,10 @@ def test_get_configure_functions(sample_config_path):
     - sample_config_path (str): The path to the temporary test configuration file.
     """
     with OPNsenseModuleConfig(
-        module_name="test_module", check_mode=False, path=sample_config_path
+        module_name="test_module",
+        config_context_names=["test_module"],
+        path=sample_config_path,
+        check_mode=False,
     ) as new_config:
         requirements: Dict = new_config._get_configure_functions()
 
@@ -307,7 +323,10 @@ def test_changed(sample_config_path):
     - sample_config_path (str): The path to the temporary test configuration file.
     """
     with OPNsenseModuleConfig(
-        "test_module", check_mode=False, path=sample_config_path
+        module_name="test_module",
+        config_context_names=["test_module"],
+        path=sample_config_path,
+        check_mode=False,
     ) as new_config:
         new_config.set(value="testtest", setting="hostname")
         assert new_config.changed
@@ -322,7 +341,10 @@ def test_get_setting(sample_config_path):
     - sample_config_path (str): The path to the temporary test configuration file.
     """
     with OPNsenseModuleConfig(
-        "test_module", check_mode=False, path=sample_config_path
+        module_name="test_module",
+        config_context_names=["test_module"],
+        path=sample_config_path,
+        check_mode=False,
     ) as new_config:
         hostname_setting: Element = new_config.get("hostname")
         assert isinstance(hostname_setting, Element)
@@ -338,7 +360,10 @@ def test_save_on_changed(sample_config_path):
     - sample_config_path (str): The path to the temporary test configuration file.
     """
     with OPNsenseModuleConfig(
-        "test_module", check_mode=False, path=sample_config_path
+        module_name="test_module",
+        config_context_names=["test_module"],
+        path=sample_config_path,
+        check_mode=False,
     ) as new_config:
         new_config.set(value="testtest", setting="hostname")
         assert new_config.save()
@@ -352,7 +377,10 @@ def test_save_on_not_changed(sample_config_path):
     - sample_config_path (str): The path to the temporary test configuration file.
     """
     with OPNsenseModuleConfig(
-        "test_module", check_mode=False, path=sample_config_path
+        module_name="test_module",
+        config_context_names=["test_module"],
+        path=sample_config_path,
+        check_mode=False,
     ) as new_config:
         assert not new_config.save()
 
@@ -366,7 +394,10 @@ def test_diff_on_change(sample_config_path):
     - sample_config_path (str): The path to the temporary test configuration file.
     """
     with OPNsenseModuleConfig(
-        "test_module", check_mode=False, path=sample_config_path
+        module_name="test_module",
+        config_context_names=["test_module"],
+        path=sample_config_path,
+        check_mode=False,
     ) as new_config:
         new_config.set(value="testtest", setting="hostname")
         diff = new_config.diff
@@ -391,37 +422,10 @@ def test_diff_on_no_change(sample_config_path):
     - sample_config_path (str): The path to the temporary test configuration file.
     """
     with OPNsenseModuleConfig(
-        "test_module", check_mode=False, path=sample_config_path
+        module_name="test_module",
+        config_context_names=["test_module"],
+        path=sample_config_path,
+        check_mode=False,
     ) as new_config:
         diff = new_config.diff
         assert diff["before"] == diff["after"]
-
-
-def test_exit_on_changed_not_in_checkmode(sample_config_path):
-    """
-    Test that a RuntimeError is raised when configuration changes are not saved.
-    """
-    with pytest.raises(
-        RuntimeError, match="Config has changed. Cannot exit without saving."
-    ):
-        with OPNsenseModuleConfig(
-            "test_module", check_mode=False, path=sample_config_path
-        ) as new_config:
-            new_config.set(value="testtest", setting="hostname")
-            # The RuntimeError should be raised here, when exiting the context manager
-
-
-def test_exit_on_changed_in_checkmode(sample_config_path):
-    """
-    Verifies that the OPNsenseModuleConfig context manager exits without error
-    in check mode even after changes are made. The test confirms that
-    RuntimeError is not raised when the 'check_mode' is set to True, even
-    if changes are applied to the configuration. This is because in check mode,
-    changes should not be saved, and thus, the process should exit cleanly
-    without raising a RuntimeError about unsaved changes.
-    """
-
-    with OPNsenseModuleConfig(
-        "test_module", check_mode=True, path=sample_config_path
-    ) as new_config:
-        new_config.set(value="testtest", setting="hostname")

--- a/tests/unit/plugins/module_utils/test_opnsense_utils.py
+++ b/tests/unit/plugins/module_utils/test_opnsense_utils.py
@@ -1,6 +1,6 @@
 # Copyright: (c) 2023, Puzzle ITC
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-"""Tests for the plugins.module_utils.opnsense_utils module."""
+"""Tests for the ansible_collections.puzzle.opnsense.plugins.module_utils.opnsense_utils module."""
 
 from __future__ import absolute_import, division, print_function
 

--- a/tests/unit/plugins/module_utils/test_version_utils.py
+++ b/tests/unit/plugins/module_utils/test_version_utils.py
@@ -1,6 +1,6 @@
 # Copyright: (c) 2023, Puzzle ITC
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-"""Tests for the plugins.module_utils.version_utils module."""
+"""Tests for the ansible_collections.puzzle.opnsense.plugins.module_utils.version_utils module."""
 
 
 # This is probably intentional and required for the fixture

--- a/tests/unit/plugins/module_utils/test_xml_utils.py
+++ b/tests/unit/plugins/module_utils/test_xml_utils.py
@@ -1,7 +1,7 @@
 # Copyright: (c) 2023, Fabio Bertagna <bertagna@puzzle.ch>, Puzzle ITC
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-"""Tests for the plugins.module_utils.xml_utils module."""
+"""Tests for the ansible_collections.puzzle.opnsense.plugins.module_utils.xml_utils module."""
 
 # This is probably intentional and required for the fixture
 # pylint: disable=redefined-outer-name


### PR DESCRIPTION
We encountered the use case, where we need to use the same xpaths from our module_index.VERSION_MAP across different modules. Eg. the firewall_rules module will need information about interfaces, while we intend to implement an `interface`  module which will also require version tracking for those interface-related xpaths. To prevent the case where we will need to track the respective xpaths across multiple module blocks inside our VERSION_MAP, we introduced config_contexts. Each context contains its settings with the corresponding xpath, its php_configure_functions, and its php_requirements.