### PR TITLE
XML Utility: elements_equal

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -208,16 +208,18 @@ jobs:
           # for Ansible >=2.15 Python 3.6 support has been deprecated
           - ansible: devel
             python: '3.6'
+          - ansible: devel
+            python: '3.7'
           - ansible: stable-2.12
-            python: 3.11
+            python: "3.11"
           - ansible: stable-2.12
-            python: 3.12
+            python: "3.12"
           - ansible: stable-2.13
-            python: 3.11
+            python: "3.11"
           - ansible: stable-2.13
-            python: 3.12
+            python: "3.12"
           - ansible: stable-2.14
-            python: 3.12
+            python: "3.12"
 
 
     steps:

--- a/plugins/module_utils/xml_utils.py
+++ b/plugins/module_utils/xml_utils.py
@@ -16,9 +16,7 @@ __metaclass__ = type
 ###############################
 
 
-def dict_to_etree(
-    tag: str, data: Optional[Union[int, str, list, dict]]
-) -> Optional[List[Element]]:
+def dict_to_etree(tag: str, data: Optional[Union[int, str, list, dict]]) -> Optional[List[Element]]:
     """
     Converts a Python dictionary to an ElementTree.Element structure.
 
@@ -42,7 +40,10 @@ def dict_to_etree(
     if return_value is not None:
         return return_value
 
-    raise ValueError("Only values of type int, str, dict or list are supported.")
+    raise ValueError(
+        f"You provided an unsupported data type {type(data)}."
+        "Only values of type int, str, dict or list are supported."
+    )
 
 
 def _create_element(tag: str, data: Optional[Union[int, str]]) -> Element:
@@ -120,9 +121,7 @@ def _process_list(tag: str, data: list) -> List[Element]:
     return new_elements
 
 
-def _process_dict_list(
-    tag: str, input_dict: dict, root: Optional[Element]
-) -> Optional[Element]:
+def _process_dict_list(tag: str, input_dict: dict, root: Optional[Element]) -> Optional[Element]:
     """
     Processes a dictionary within a list, converting its key-value pairs to ElementTree.Element.
 

--- a/plugins/module_utils/xml_utils.py
+++ b/plugins/module_utils/xml_utils.py
@@ -16,7 +16,9 @@ __metaclass__ = type
 ###############################
 
 
-def dict_to_etree(tag: str, data: Optional[Union[int, str, list, dict]]) -> Optional[List[Element]]:
+def dict_to_etree(
+    tag: str, data: Optional[Union[int, str, list, dict]]
+) -> Optional[List[Element]]:
     """
     Converts a Python dictionary to an ElementTree.Element structure.
 
@@ -121,7 +123,9 @@ def _process_list(tag: str, data: list) -> List[Element]:
     return new_elements
 
 
-def _process_dict_list(tag: str, input_dict: dict, root: Optional[Element]) -> Optional[Element]:
+def _process_dict_list(
+    tag: str, input_dict: dict, root: Optional[Element]
+) -> Optional[Element]:
     """
     Processes a dictionary within a list, converting its key-value pairs to ElementTree.Element.
 
@@ -221,5 +225,7 @@ def elements_equal(e1, e2) -> bool:
     # Tags have children
     return all(
         elements_equal(c1, c2)
-        for c1, c2 in zip(sorted(e1, key=lambda x: x.tag), sorted(e2, key=lambda x: x.tag))
+        for c1, c2 in zip(
+            sorted(e1, key=lambda x: x.tag), sorted(e2, key=lambda x: x.tag)
+        )
     )

--- a/plugins/module_utils/xml_utils.py
+++ b/plugins/module_utils/xml_utils.py
@@ -214,8 +214,8 @@ def elements_equal(e1, e2) -> bool:
         # 2. or check if one text is '1' and the other is None with no children
         return (
             (_is_whitespace_or_none(e1.text) == _is_whitespace_or_none(e2.text))
-            or (e1.text == "1" and not e2.text and not len(e2))
-            or (e2.text == "1" and not e1.text and not len(e1))
+            or (e1.text == "1" and not e2.text and not e2)
+            or (e2.text == "1" and not e1.text and not e1)
         )
 
     # Tags have children

--- a/plugins/module_utils/xml_utils.py
+++ b/plugins/module_utils/xml_utils.py
@@ -181,3 +181,45 @@ def etree_to_dict(input_etree: Element) -> dict:
                 result[key] = value
 
     return {input_etree.tag: result}
+
+
+def _is_whitespace_or_none(text) -> bool:
+    """
+    Checks if a given string is a string of whitespace characters or None.
+    Args:
+        text: the string to perform the check on.
+    Returns:
+        bool: True if the 'text' string is None or a whitespace string.
+    """
+    return text is None or text.strip() == ""
+
+
+def elements_equal(e1, e2) -> bool:
+    """
+    Compare two XML elements for equality.
+    Args:
+        e1 (Element): The first XML element.
+        e2 (Element): The second XML element.
+    Returns:
+        bool: True if the elements are equal, False otherwise.
+    """
+
+    # Check basic attributes for equality
+    if len(e1) != len(e2) or e1.attrib != e2.attrib or e1.tag != e2.tag:
+        return False
+
+    # Leaf elements with no children
+    if len(e1) == 0 and len(e2) == 0:
+        # 1. Check if texts are exactly the same (ignoring whitespaces and None)
+        # 2. or check if one text is '1' and the other is None with no children
+        return (
+            (_is_whitespace_or_none(e1.text) == _is_whitespace_or_none(e2.text))
+            or (e1.text == "1" and not e2.text and not len(e2))
+            or (e2.text == "1" and not e1.text and not len(e1))
+        )
+
+    # Tags have children
+    return all(
+        elements_equal(c1, c2)
+        for c1, c2 in zip(sorted(e1, key=lambda x: x.tag), sorted(e2, key=lambda x: x.tag))
+    )

--- a/tests/unit/plugins/module_utils/test_xml_utils.py
+++ b/tests/unit/plugins/module_utils/test_xml_utils.py
@@ -330,16 +330,12 @@ def test_etree_to_dict__simple_tree(etree_root: Element) -> None:
 
     input_children: List[Element] = list(etree_root)
     for child in input_children:
-        assert any(
-            list(filter(lambda i, c=child: c.tag in list(i.keys()), output_dict["foo"]))
-        )
+        assert any(list(filter(lambda i, c=child: c.tag in list(i.keys()), output_dict["foo"])))
 
 
 @pytest.mark.parametrize(
     "etree_root",
-    [
-        "<foo><bar><bob>1</bob><cat>2</cat></bar><john><bob>3</bob><cat>4</cat></john></foo>"
-    ],
+    ["<foo><bar><bob>1</bob><cat>2</cat></bar><john><bob>3</bob><cat>4</cat></john></foo>"],
     indirect=True,
 )
 def test_etree_to_dict__multiple_nested_dicts(etree_root: Element) -> None:
@@ -384,3 +380,66 @@ def test_etree_to_dict__multiple_nested_dicts(etree_root: Element) -> None:
         assert child_dict["bob"] is not None
         assert "cat" in list(child_dict.keys())
         assert child_dict["cat"] is not None
+
+
+def test_elements_equal_without_children():
+    """
+    Tests elements_equal function with elements having the same tag and text content.
+
+    eg: <test>test text</test> == <test>test text</test>
+    """
+    e1 = Element("test")
+    e1.text = "test text"
+    e2 = Element("test")
+    e2.text = "test text"
+
+    assert xml_utils.elements_equal(e1, e2)
+
+
+def test_elements_equal_without_children_whitespace_matches():
+    """
+    Test that elements_equal function considers a whitespace only text the same as a NoneType text.
+
+    eg:
+    <test/> == <test>   </test>
+    """
+    e1 = Element("test")
+    e1.text = None
+    e2 = Element("test")
+    e2.text = "            "
+
+    assert xml_utils.elements_equal(e1, e2)
+
+
+def test_elements_equal_without_children_none_and_1():
+    """
+    Tests elements_equal function matches a boolean flag "1" the same as an empty element.
+
+    eg:
+    <test/> == <test>1</test>
+    """
+    e1 = Element("test")
+    e1.text = "1"
+    e2 = Element("test")
+    e2.text = None
+
+    assert xml_utils.elements_equal(e1, e2)
+
+
+def test_elements_equal_with_children():
+    """
+    Tests elements_equal function matches recursively equal elements.
+    """
+    e1 = Element("test")
+    e1c1 = Element("child_1")
+    e1c1.text = "some_text"
+    e1c2 = Element("child_2")
+    e1c2.text = "some_text_as_well"
+    e1.extend([e1c1, e1c2])
+    e2 = Element("test")
+    e2c1 = Element("child_1")
+    e2c1.text = "some_text     \n"
+    e2c2 = Element("child_2")
+    e2c2.text = "\n   some_text     \n"
+    e2.extend([e2c1, e2c2])
+    assert xml_utils.elements_equal(e1, e2)

--- a/tests/unit/plugins/module_utils/test_xml_utils.py
+++ b/tests/unit/plugins/module_utils/test_xml_utils.py
@@ -330,12 +330,16 @@ def test_etree_to_dict__simple_tree(etree_root: Element) -> None:
 
     input_children: List[Element] = list(etree_root)
     for child in input_children:
-        assert any(list(filter(lambda i, c=child: c.tag in list(i.keys()), output_dict["foo"])))
+        assert any(
+            list(filter(lambda i, c=child: c.tag in list(i.keys()), output_dict["foo"]))
+        )
 
 
 @pytest.mark.parametrize(
     "etree_root",
-    ["<foo><bar><bob>1</bob><cat>2</cat></bar><john><bob>3</bob><cat>4</cat></john></foo>"],
+    [
+        "<foo><bar><bob>1</bob><cat>2</cat></bar><john><bob>3</bob><cat>4</cat></john></foo>"
+    ],
     indirect=True,
 )
 def test_etree_to_dict__multiple_nested_dicts(etree_root: Element) -> None:


### PR DESCRIPTION
These changes add a utility for ElementTree element comparison by value.

The default equality comparison eg. "element_1 == element_2" does not work since the objects are compared by reference by default:
```python
>>> from xml.etree.ElementTree import Element
>>> e1 = Element("test")
>>> e2 = Element("test")
>>> e1 == e2
False
```

This utility function allows for an equality check based on the element's tag, text, and attribute values