### PR TITLE
Drop ansible core devel python 3.7 support

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -208,16 +208,18 @@ jobs:
           # for Ansible >=2.15 Python 3.6 support has been deprecated
           - ansible: devel
             python: '3.6'
+          - ansible: devel
+            python: '3.7'
           - ansible: stable-2.12
-            python: 3.11
+            python: "3.11"
           - ansible: stable-2.12
-            python: 3.12
+            python: "3.12"
           - ansible: stable-2.13
-            python: 3.11
+            python: "3.11"
           - ansible: stable-2.13
-            python: 3.12
+            python: "3.12"
           - ansible: stable-2.14
-            python: 3.12
+            python: "3.12"
 
 
     steps:


### PR DESCRIPTION
Ansible Core devel drops python 3.7 support: https://forum.ansible.com/t/ansible-core-devel-drops-support-for-python-3-7/4736