### PR TITLE
add opnsense version to ModuleMisconfigurationError/UnsupportedModuleSettingError exceptions

### DIFF
--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -70,6 +70,12 @@ class UnsupportedModuleSettingError(Exception):
     unsupported setting in a Module.
     """
 
+    def __init__(self, message, opnsense_version=None):
+        # Call the base class constructor with the parameters it needs
+        super().__init__(message)
+        if opnsense_version is not None:
+            self.opnsense_version = opnsense_version
+
 
 class OPNsenseModuleConfig:
     """
@@ -216,9 +222,10 @@ class OPNsenseModuleConfig:
         for cfg_map in self._config_maps.values():
             supported_settings.extend(cfg_map.keys())
         raise UnsupportedModuleSettingError(
-            f"Setting '{setting_name}' is not supported in module '{self._module_name}' "
+            message=f"Setting '{setting_name}' is not supported in module '{self._module_name}' "
             f"for OPNsense version '{self._opnsense_version}'."
-            f"Supported settings are {supported_settings}"
+            f"Supported settings are {supported_settings}",
+            opnsense_version=self._opnsense_version,
         )
 
     def _get_php_requirements(self) -> list:

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -40,7 +40,15 @@ class ModuleMisconfigurationError(Exception):
     """
     Exception raised when module configurations are not in the expected format as defined in the
     ansible_collections.puzzle.opnsense.plugins.module_utils.module_index.VERSION_MAP.
+
+    Attributes:
+        opnsense_version (str): The OPNsense version
     """
+
+    def __init__(self, message, opnsense_version):
+        # Call the base class constructor with the parameters it needs
+        super().__init__(message)
+        self.opnsense_version = opnsense_version
 
 
 class UnsupportedOPNsenseVersion(Exception):
@@ -241,9 +249,10 @@ class OPNsenseModuleConfig:
             # ensure php_requirements are defined as a list
             if not isinstance(php_requirements, list):
                 raise ModuleMisconfigurationError(
-                    f"PHP requirements (php_requirements) for the module '{self._module_name}' are "
-                    "not provided as a list in the VERSION_MAP using OPNsense version"
-                    f"'{self._opnsense_version}'."
+                    message="PHP requirements (php_requirements) for the module "
+                    f"'{self._module_name}' are not provided as a list in the "
+                    f"VERSION_MAP using OPNsense version '{self._opnsense_version}'.",
+                    opnsense_version=self._opnsense_version,
                 )
 
             all_php_requirements.extend(php_requirements)
@@ -295,10 +304,11 @@ class OPNsenseModuleConfig:
             # ensure configure_functions are defined as a list
             if not isinstance(configure_functions, dict):
                 raise ModuleMisconfigurationError(
-                    "Configure functions (configure_functions) for the module "
+                    message="Configure functions (configure_functions) for the module "
                     f"'{self._module_name}' are "
                     "not provided as a list in the VERSION_MAP using OPNsense version "
-                    f"'{self._opnsense_version}'."
+                    f"'{self._opnsense_version}'.",
+                    opnsense_version=self._opnsense_version,
                 )
 
             all_configure_functions.update(configure_functions)
@@ -396,7 +406,8 @@ class OPNsenseModuleConfig:
 
         if xpath is None:
             raise ModuleMisconfigurationError(
-                f"Could not access given setting {setting}"
+                message=f"Could not access given setting {setting}",
+                opnsense_version=self._opnsense_version,
             )
         # create a copy of the _config_dict
         _setting: Element = self._config_xml_tree.find(xpath)

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -45,10 +45,11 @@ class ModuleMisconfigurationError(Exception):
         opnsense_version (str): The OPNsense version
     """
 
-    def __init__(self, message, opnsense_version):
+    def __init__(self, message, opnsense_version=None):
         # Call the base class constructor with the parameters it needs
         super().__init__(message)
-        self.opnsense_version = opnsense_version
+        if opnsense_version is not None:
+            self.opnsense_version = opnsense_version
 
 
 class UnsupportedOPNsenseVersion(Exception):

--- a/tests/unit/plugins/module_utils/test_config_utils.py
+++ b/tests/unit/plugins/module_utils/test_config_utils.py
@@ -291,7 +291,7 @@ def test_php_requirements_must_be_list(sample_config_path):
             ModuleMisconfigurationError,
             match=(
                 r"PHP requirements \(php_requirements\) for the module 'invalid_php_requirements' "
-                r"are not provided as a list in the VERSION_MAP using OPNsense version"
+                r"are not provided as a list in the VERSION_MAP using OPNsense version "
                 r"'OPNsense Test'."
             ),
         ):


### PR DESCRIPTION
This PR adds the opnsense version to the `ModuleMisconfigurationError` exception, which allows a more meaningful error message in case a user tries to use module params which are not supported on the currently used opnsense version such as:

```
TASK [Converge - Set preserve logs] **************************************************************************************************************************

fatal: [opnsense]: FAILED! => {"changed": false, "details": "Could not access given setting max_log_file_size_mb", "msg": "Parameter max_log_file_size_mb is not available in OPNsense 23.1"}
