### PR TITLE
update cfg mgr exit method

### DIFF
--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -160,6 +160,13 @@ class OPNsenseModuleConfig:
             RuntimeError: If there are unsaved changes in the configuration.
         """
         if exc_type:
+            # module.fail_json will always yield a SystemExit exception
+            # we need to raise this exception "as is" to avoid ansible warnings
+            # If however an unexpected exception was risen which was not a result of
+            # module.fail_json raising this warning is ok, and we need the exceptions
+            # details to troubleshoot the issue
+            if isinstance(exc_val, SystemExit):
+                raise
             raise exc_type(f"Exception occurred: {exc_val}")
         if self.changed and not self._check_mode:
             raise RuntimeError("Config has changed. Cannot exit without saving.")


### PR DESCRIPTION
When we use `module.fail_json` in our modules, this will cause our config managers ` __exit__` function to raise an exception. This will cause Ansible to display a warning (`Module invocation had junk after the JSON data`):

```
TASK [Converge - Set preserve logs] **************************************************************************************************************************
[WARNING]: Module invocation had junk after the JSON data: Exception occurred: 1
fatal: [opnsense]: FAILED! => {"changed": false, "msg": "Parameter max_log_file_size_mb is not supported in OPNsense 23.1"}
```

This is probably ok if the error was caused by an unhandled exception, but it's not what we expect if we handle an error in our module and deliberately call `module.fail_json`. This PR fixes the by raising any `SystemExit` exceptions "as is" which enables Ansible to correctly recognize the call to `module.fail_json` without displaying the warning.