### PR TITLE
Drop/py36 37 support

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -187,8 +187,6 @@ jobs:
           - devel
         # - milestone
         python:
-          - '3.6'
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
@@ -205,21 +203,16 @@ jobs:
             python: '3.10'
           - ansible: stable-2.11
             python: '3.10'
-          # for Ansible >=2.15 Python 3.6 support has been deprecated
-          - ansible: devel
-            python: '3.6'
-          - ansible: devel
-            python: '3.7'
           - ansible: stable-2.12
-            python: "3.11"
+            python: '3.11'
           - ansible: stable-2.12
-            python: "3.12"
+            python: '3.12'
           - ansible: stable-2.13
-            python: "3.11"
+            python: '3.11'
           - ansible: stable-2.13
-            python: "3.12"
+            python: '3.12'
           - ansible: stable-2.14
-            python: "3.12"
+            python: '3.12'
 
 
     steps:

--- a/docs/docsite/rst/development_guide.rst
+++ b/docs/docsite/rst/development_guide.rst
@@ -34,7 +34,7 @@ Ansible documentation (`Prepare your environment
     git clone git@github.com/<YOUR_GITHUB_HANDLE>/puzzle.opnsense.git \
        <YOUR_WORKING_DIR>/ansible_collections/puzzle/opnsense
 
-3. This collection supports Python versions >=3.6,<3.12 therefore make sure your system
+3. This collection supports Python versions >=3.8,<3.12 therefore make sure your system
    supports any of those versions.
 4. Setup the pipenv:
 

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,4 +1,4 @@
 ---
 # ansible-test configurations
 modules:
-  python_requires: ">=3.6"
+  python_requires: ">=3.8"


### PR DESCRIPTION
As described in the issue, this change removes python 3.6 and 3.7 from our project.