### PR TITLE
Exclude php_requirements and configure_functions in settings support exception

### DIFF
--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -213,6 +213,12 @@ class OPNsenseModuleConfig:
         supported_settings: List[str] = []
         for cfg_map in self._config_maps.values():
             supported_settings.extend(cfg_map.keys())
+
+        if "php_requirements" in supported_settings:
+            supported_settings.remove("php_requirements")
+        if "configure_functions" in supported_settings:
+            supported_settings.remove("configure_functions")
+
         raise UnsupportedModuleSettingError(
             f"Setting '{setting_name}' is not supported in module '{self._module_name}' "
             f"for OPNsense version '{self.opnsense_version}'."


### PR DESCRIPTION
When providing feedback due to a version not supporting a module setting, the `php_requirements` and `configure_functions` should be excluded in the exception message, since they are not relevant for the semantic usage of settings based on the OPNsense version.  