### PR TITLE
Use 'product_series' for version detection

### DIFF
--- a/changelogs/fragments/109-use-product-series-in-version-detection.yml
+++ b/changelogs/fragments/109-use-product-series-in-version-detection.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - version_util - Use `product_series` for version detection to avoid minor version
+    mismatches.

--- a/plugins/module_utils/version_utils.py
+++ b/plugins/module_utils/version_utils.py
@@ -38,7 +38,7 @@ def get_opnsense_version() -> str:
             f"There was an error getting the version {exc}"
         ) from exc
 
-    product_version = version_dict.get("product_version", None)
+    product_version = version_dict.get("product_series", None)
     if product_version is None:
         raise OPNSenseVersionUsageError(
             "There was an error getting the version: "


### PR DESCRIPTION
To avoid tracking OPNsense versions for every bugfix version (eg. 24.1.4) we can focus just on minor releases (eg. 24.1). 
 This is achieved by detecting the OPNsense version using the 'product_series' attribute of the `opnsense-version -O` command output.

Changes have been successfully tested on all present molecule scenarios.

Resolves #108 