### PR TITLE
Fix user extra attributes in system_access_users

### DIFF
--- a/changelogs/fragments/112-fix-user-extra-attributes-in-system_access_users.yml
+++ b/changelogs/fragments/112-fix-user-extra-attributes-in-system_access_users.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+    - system_access_users_utils - Handle additional XML attributes of user
+      objects that are not yet handled by the system_access_users module.

--- a/plugins/module_utils/system_access_users_utils.py
+++ b/plugins/module_utils/system_access_users_utils.py
@@ -241,7 +241,7 @@ class User:
     extra_attrs: Dict[str, Any] = field(default_factory=dict, repr=False)
 
     def __init__(self, **kwargs):
-        _attr_names: set[str] = set([f.name for f in dataclasses.fields(self)])
+        _attr_names: set[str] = {f.name for f in dataclasses.fields(self)}
         _extra_attrs: dict = {}
         for key, value in kwargs.items():
             if key in _attr_names:
@@ -257,9 +257,9 @@ class User:
         if not isinstance(other, User):
             return False
 
-        for field in fields(self):
-            if field.name not in ["password", "uid", "otp_seed", "apikeys"]:
-                if getattr(self, field.name) != getattr(other, field.name):
+        for _field in fields(self):
+            if _field.name not in ["password", "uid", "otp_seed", "apikeys"]:
+                if getattr(self, _field.name) != getattr(other, _field.name):
                     return False
 
         return True

--- a/tests/unit/plugins/module_utils/test_system_access_users_utils.py
+++ b/tests/unit/plugins/module_utils/test_system_access_users_utils.py
@@ -207,6 +207,7 @@ def test_user_with_api_key_from_xml():
     assert test_user.shell == UserLoginShell.SH
     assert test_user.uid == "1001"
 
+
 def test_user_from_ansible_module_params_simple(sample_config_path):
     test_params: dict = {
         "username": "vagrant",

--- a/tests/unit/plugins/module_utils/test_system_access_users_utils.py
+++ b/tests/unit/plugins/module_utils/test_system_access_users_utils.py
@@ -73,6 +73,7 @@ TEST_XML: str = """<?xml version="1.0"?>
                 <password>$2y$10$1BvUdvwM.a.dJACwfeNfAOgNT6Cqc4cKZ2F6byyvY8hIK9I8fn36O</password>
                 <scope>user</scope>
                 <name>test_user_1</name>
+                <user_dn>uid=test_user_1,ou=users,dc=example,dc=com</user_dn>
                 <descr>test_user_1</descr>
                 <expires />
                 <authorizedkeys />

--- a/tests/unit/plugins/module_utils/test_system_access_users_utils.py
+++ b/tests/unit/plugins/module_utils/test_system_access_users_utils.py
@@ -206,25 +206,6 @@ def test_user_with_api_key_from_xml():
     assert test_user.shell == UserLoginShell.SH
     assert test_user.uid == "1001"
 
-
-def test_user_to_etree():
-    test_user: User = User(
-        password="$2y$10$1BvUdvwM.a.dJACwfeNfAOgNT6Cqc4cKZ2F6byyvY8hIK9I8fn36O",
-        scope="user",
-        name="vagrant",
-        descr="vagrant box management",
-        shell="/bin/sh",
-        uid="1000",
-    )
-
-    test_element = test_user.to_etree()
-
-    orig_etree: Element = ElementTree.fromstring(TEST_XML)
-    orig_user: Element = list(list(orig_etree)[0])[2]
-
-    assert xml_utils.elements_equal(test_element, orig_user)
-
-
 def test_user_from_ansible_module_params_simple(sample_config_path):
     test_params: dict = {
         "username": "vagrant",


### PR DESCRIPTION
These changes handle additional user attributes that are not (yet) handled by the system_access_users module.
They are stored in a generic `Users.extra_attrs` field, and written back when writing the config.


Resolves #111 