### PR TITLE
Include plugin interfaces in interfaces_assignment module

### DIFF
--- a/changelogs/fragments/129-include-plugin-interfaces-for-assignments.yml
+++ b/changelogs/fragments/129-include-plugin-interfaces-for-assignments.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - interfaces_assignments - Include plugin interfaces such as VLAN, VXLANs etc. in validations.

--- a/plugins/module_utils/interfaces_assignments_utils.py
+++ b/plugins/module_utils/interfaces_assignments_utils.py
@@ -308,8 +308,15 @@ class InterfacesSet(OPNsenseModuleConfig):
             "php_requirements"
         ]
         php_command = """
+                    /* get physical network interfaces */
                     foreach (get_interface_list() as $key => $item) {
                         echo $key.',';
+                    }
+                    /* get virtual network interfaces */
+                    foreach (plugins_devices() as $item){
+                        foreach ($item["names"] as $key => $if ) {
+                            echo $key.',';
+                        }
                     }
                     """
 


### PR DESCRIPTION
Those changes include all plugin devices (Bridge, VLAN, VXLAN ...etc ) in the interfaces_assignments module validation.

Relates to the mentioned issue in #125 .