### PR TITLE
Draft: Add config object base class

### DIFF
--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -613,6 +613,9 @@ class ConfigObject:
             elif hasattr(f_val, "value"):
                 fields[f_name] = f_val.value
 
+            if isinstance(f_val, bool):
+                fields[f_name] = "1" if f_val else "0"
+
         # extract extra_data to write it correctly to XML
         for e_name, e_val in self.extra_data.items():
             fields[e_name] = e_val

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -598,18 +598,20 @@ class ConfigObject:
             if not field.name.startswith("_")
         }
 
-        # for any field that is of subtype of ConfigObject, i.e. it has
-        # a _get_class_data_for_xml function, convert it to a dict
         for f_name, f_val in fields.items():
+            # for any field that is of subtype of ConfigObject, i.e. it has
+            # a _get_class_data_for_xml function, convert it to a dict
             if hasattr(f_val, "get_class_data_for_xml"):
                 fields[f_name] = f_val.get_class_data_for_xml()
+
+            # Handle Enum fields which have a value
             elif hasattr(f_val, "value"):
                 fields[f_name] = f_val.value
 
+
         # extract extra_data to write it correctly to XML
-        for e_name, e_val in fields["extra_data"].items():
+        for e_name, e_val in self.extra_data.items():
             fields[e_name] = e_val
-        del fields["extra_data"]
 
         return fields
 

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -484,3 +484,18 @@ class OPNsenseModuleConfig:
                     config_diff_after.update({xpath: in_memory_element.text})
 
         return {"before": config_diff_before, "after": config_diff_after}
+
+
+class ConfigObject:
+    """
+    Base class for config object abstraction.
+    """
+
+    @classmethod
+    def from_ansible_module_params(cls, params: dict) -> "ConfigObject":
+        """
+
+        :param params: raw ansible module execution parameters.
+        :return: instance of the config object class.
+        """
+        return cls(**params)

--- a/plugins/module_utils/config_utils.py
+++ b/plugins/module_utils/config_utils.py
@@ -11,6 +11,8 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import abc
+import dataclasses
 from typing import List, Optional, Dict
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
@@ -486,16 +488,29 @@ class OPNsenseModuleConfig:
         return {"before": config_diff_before, "after": config_diff_after}
 
 
+@dataclasses.dataclass
 class ConfigObject:
     """
     Base class for config object abstraction.
     """
 
     @classmethod
+    @abc.abstractmethod
+    def preprocess_ansible_module_params(cls, raw_params: dict) -> dict:
+        """
+        Performs the mapping of the module parameters to the required data
+        for the instantiation of the given dataclass.
+        :param raw_params: ansible parameters as provided by the invocation.
+        :return:
+        """
+        raise NotImplementedError()
+
+    @classmethod
     def from_ansible_module_params(cls, params: dict) -> "ConfigObject":
         """
-
+        Creates instance from given ansible module parameters.
         :param params: raw ansible module execution parameters.
         :return: instance of the config object class.
         """
-        return cls(**params)
+        preprocessed_params: dict = cls.preprocess_ansible_module_params(params)
+        return cls(**preprocessed_params)

--- a/plugins/module_utils/xml_utils.py
+++ b/plugins/module_utils/xml_utils.py
@@ -43,8 +43,9 @@ def dict_to_etree(
         return return_value
 
     raise ValueError(
-        f"You provided an unsupported data type {type(data)}."
-        "Only values of type int, str, dict or list are supported."
+        f"You provided an unsupported data type {type(data)}. "
+        "Only values of type int, str, dict or list are supported. "
+        f"Data: {data}"
     )
 
 

--- a/tests/unit/plugins/module_utils/test_config_utils.py
+++ b/tests/unit/plugins/module_utils/test_config_utils.py
@@ -589,7 +589,10 @@ def test_success_set_on_empty_leaf_node(sample_config_path):
 ###
 
 
+# pylint: disable=too-few-public-methods
 class TestType(ListEnum):
+    """Enumeration for Test Types"""
+
     __test__ = False
     ONE = "one"
     TWO = "two"
@@ -597,6 +600,7 @@ class TestType(ListEnum):
 
 @dataclasses.dataclass
 class TestConfigObject(ConfigObject):
+    """Configuration Object representation"""
 
     __test__ = False
     name: str
@@ -606,12 +610,16 @@ class TestConfigObject(ConfigObject):
 
     @classmethod
     def preprocess_ansible_module_params(cls, raw_params: dict) -> dict:
+        """Preprocess params from Ansible module for TestConfigObject"""
+
         params: dict = {**raw_params}
         params["pretty_name"] = params["name"].capitalize()
         return params
 
     @classmethod
     def preprocess_from_xml_data(cls, raw_xml_data: dict) -> dict:
+        """Preprocess raw XML data for TestConfigObject instantiation"""
+
         params: dict = {**raw_xml_data}
         params["pretty_name"] = params["name"].capitalize()
         return params
@@ -619,6 +627,7 @@ class TestConfigObject(ConfigObject):
 
 @dataclasses.dataclass
 class TestNestedConfigObject(ConfigObject):
+    """Nested Configuration Object representation"""
 
     __test__ = False
     sub_element: TestConfigObject
@@ -626,6 +635,8 @@ class TestNestedConfigObject(ConfigObject):
 
     @classmethod
     def preprocess_ansible_module_params(cls, raw_params: dict) -> dict:
+        """Preprocess params from Ansible module for TestNestedConfigObject"""
+
         return {"sub_element": {"name": raw_params["sub_element_name"]}}
 
 
@@ -655,6 +666,8 @@ def test_config_object_preprocessed_parameters() -> None:
 
 
 def test_simple_obj_root_tag_name() -> None:
+    """Test TestConfigObject creation from simple XML with root tag"""
+
     simple: str = """
         <test>
             <name>test_object</name>
@@ -672,6 +685,8 @@ def test_simple_obj_root_tag_name() -> None:
 
 
 def test_simple_obj_extra_data() -> None:
+    """Test TestConfigObject creation from XML with extra data"""
+
     simple: str = """
         <test>
             <name>test_object</name>
@@ -693,6 +708,9 @@ def test_simple_obj_extra_data() -> None:
 
 
 def test_simple_obj_extra_data_to_xml() -> None:
+    """Test TestConfigObject extra data inclusion in generated XML"""
+
+    # pylint: disable=unexpected-keyword-arg
     simple_obj: TestConfigObject = TestConfigObject(
         name="test",
         pretty_name="Test Object",
@@ -710,6 +728,9 @@ def test_simple_obj_extra_data_to_xml() -> None:
 
 
 def test_nested_obj_extra_data_to_xml() -> None:
+    """Test nested TestConfigObject extra data inclusion in generated XML"""
+
+    # pylint: disable=unexpected-keyword-arg
     nested_obj: TestNestedConfigObject = TestNestedConfigObject(
         sub_element=TestConfigObject(
             name="test",

--- a/tests/unit/plugins/module_utils/test_config_utils.py
+++ b/tests/unit/plugins/module_utils/test_config_utils.py
@@ -588,8 +588,16 @@ def test_success_set_on_empty_leaf_node(sample_config_path):
 
 @dataclasses.dataclass
 class TestConfigObject(ConfigObject):
+
     __test__ = False
     name: str
+    pretty_name: str
+
+    @classmethod
+    def preprocess_ansible_module_params(cls, raw_params: dict) -> dict:
+        params: dict = {**raw_params}
+        params["pretty_name"] = params["name"].capitalize()
+        return params
 
 
 def test_config_object_from_ansible_params_simple() -> None:
@@ -601,3 +609,15 @@ def test_config_object_from_ansible_params_simple() -> None:
     )
 
     assert test_obj.name == module_params["name"]
+
+
+def test_config_object_preprocessed_parameters() -> None:
+    """Basic ConfigObject.from_ansible_module_params test"""
+    module_params: dict = {"name": "test object"}
+
+    test_obj: TestConfigObject = TestConfigObject.from_ansible_module_params(
+        module_params
+    )
+
+    assert test_obj.name == module_params["name"]
+    assert test_obj.pretty_name == "Test object"

--- a/tests/unit/plugins/module_utils/test_config_utils.py
+++ b/tests/unit/plugins/module_utils/test_config_utils.py
@@ -7,6 +7,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import dataclasses
+
 __metaclass__val = type
 
 import os
@@ -23,6 +25,7 @@ from ansible_collections.puzzle.opnsense.plugins.module_utils.config_utils impor
     ModuleMisconfigurationError,
     MissingConfigDefinitionForModuleError,
     UnsupportedVersionForModule,
+    ConfigObject,
 )
 
 # Test version map for OPNsense versions and modules
@@ -576,3 +579,25 @@ def test_success_set_on_empty_leaf_node(sample_config_path):
         new_config.set("test", "remote_system_username")
         assert new_config.get("remote_system_username").text == "test"
         new_config.save()
+
+
+###
+# ConfigObject Tests
+###
+
+
+@dataclasses.dataclass
+class TestConfigObject(ConfigObject):
+    __test__ = False
+    name: str
+
+
+def test_config_object_from_ansible_params_simple() -> None:
+    """Basic ConfigObject.from_ansible_module_params test"""
+    module_params: dict = {"name": "test_object"}
+
+    test_obj: TestConfigObject = TestConfigObject.from_ansible_module_params(
+        module_params
+    )
+
+    assert test_obj.name == module_params["name"]

--- a/tests/unit/plugins/module_utils/test_config_utils.py
+++ b/tests/unit/plugins/module_utils/test_config_utils.py
@@ -715,8 +715,8 @@ def test_simple_obj_extra_data_to_xml() -> None:
         name="test",
         pretty_name="Test Object",
         type=TestType.ONE,
-        extra_data={"extra": "Some Data"},
     )
+    simple_obj.extra_data = {"extra": "Some Data"}
 
     test_element: Element = simple_obj.to_xml_element()
 
@@ -731,15 +731,17 @@ def test_nested_obj_extra_data_to_xml() -> None:
     """Test nested TestConfigObject extra data inclusion in generated XML"""
 
     # pylint: disable=unexpected-keyword-arg
-    nested_obj: TestNestedConfigObject = TestNestedConfigObject(
-        sub_element=TestConfigObject(
-            name="test",
-            pretty_name="Test Object",
-            type=TestType.ONE,
-            extra_data={"extra": "Some Data"},
-        ),
-        extra_data={"extra": "data"},
+    obj: TestConfigObject = TestConfigObject(
+        name="test",
+        pretty_name="Test Object",
+        type=TestType.ONE,
     )
+    obj.extra_data = {"extra": "Some Data"}
+    nested_obj: TestNestedConfigObject = TestNestedConfigObject(
+        sub_element=obj
+    )
+
+    nested_obj.extra_data = {"extra": "data"}
 
     expected_element: Element = Element("nested")
     _expected_extra: Element = Element("extra")


### PR DESCRIPTION
These Changes adds a basic ConfigObject class which should enable inheritance for config objects (eg. FirewallRule, Groups. User, etc...) . This approach should save us a lot of boiler plate code across different config objects.