### PR TITLE
Fix logging settings module 24.7 support

### DIFF
--- a/changelogs/fragments/153-fix-system-settings-logging-24.7-support.yml
+++ b/changelogs/fragments/153-fix-system-settings-logging-24.7-support.yml
@@ -1,0 +1,3 @@
+---
+bugfixes: 
+  - system_settings_logging - fix XPath migrations for settings in 24.7.

--- a/molecule/system_settings_logging/converge.yml
+++ b/molecule/system_settings_logging/converge.yml
@@ -47,8 +47,14 @@
     - name: Compare preserve logs
       ansible.builtin.assert:
         that: "'<preservelogs>11</preservelogs>' in ( current_config.content | b64decode )"
+      when: opnsense_version["product_version"] is version('24.1', '==')
 
     - name: Compare max log file size
       ansible.builtin.assert:
         that: "'<maxfilesize>15</maxfilesize>' in ( current_config.content | b64decode )"
       when: opnsense_version["product_version"] is version('24.1', '>=')
+
+    - name: Compare preserve logs
+      ansible.builtin.assert:
+        that: "'<maxpreserve>11</maxpreserve>' in ( current_config.content | b64decode )"
+      when: opnsense_version["product_version"] is version('24.7', '>=')

--- a/plugins/module_utils/module_index.py
+++ b/plugins/module_utils/module_index.py
@@ -691,8 +691,8 @@ VERSION_MAP = {
             },
         },
         "system_settings_logging": {
-            "preserve_logs": "syslog/preservelogs",
-            "max_log_file_size_mb": "syslog/maxfilesize",
+            "preserve_logs": ".//Syslog/general/maxpreserve",
+            "max_log_file_size_mb": ".//Syslog/general/maxfilesize",
             # Add other mappings here
             "php_requirements": [
                 "/usr/local/etc/inc/config.inc",

--- a/plugins/modules/system_settings_logging.py
+++ b/plugins/modules/system_settings_logging.py
@@ -137,7 +137,10 @@ def main():
             # if the current max_log_file_size_mb value is not set in the config XML
             # config.get("max_log_file_size_mb") will be None
             try:
-                if config.get("max_log_file_size_mb") is not None and config.get("max_log_file_size_mb").text is not None:
+                if (
+                    config.get("max_log_file_size_mb") is not None
+                    and config.get("max_log_file_size_mb").text is not None
+                ):
                     current_max_log_file_size_mb = int(
                         config.get("max_log_file_size_mb").text
                     )

--- a/plugins/modules/system_settings_logging.py
+++ b/plugins/modules/system_settings_logging.py
@@ -137,7 +137,7 @@ def main():
             # if the current max_log_file_size_mb value is not set in the config XML
             # config.get("max_log_file_size_mb") will be None
             try:
-                if config.get("max_log_file_size_mb") is not None:
+                if config.get("max_log_file_size_mb") is not None and config.get("max_log_file_size_mb").text is not None:
                     current_max_log_file_size_mb = int(
                         config.get("max_log_file_size_mb").text
                     )


### PR DESCRIPTION
As showed in [this](https://github.com/opnsense/core/blob/master/src/opnsense/mvc/app/models/OPNsense/Syslog/Migrations/M1_0_2.php) syslog model migration, syslog settings have changed location in the XML config.