### PR TITLE
updated the way, users are compared while deletion

### DIFF
--- a/changelogs/fragments/160-fix-user-removal.yml
+++ b/changelogs/fragments/160-fix-user-removal.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-    - puzzle.opnsense.system_access_users - Thanks @GBBx fixed a bug while user deletion.
+    - puzzle.opnsense.system_access_users - Thanks to @GBBx fixed a bug while user deletion.

--- a/changelogs/fragments/160-fix-user-removal.yml
+++ b/changelogs/fragments/160-fix-user-removal.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - puzzle.opnsense.system_access_users - Thanks @GBBx fixed a bug while user deletion.

--- a/plugins/module_utils/system_access_users_utils.py
+++ b/plugins/module_utils/system_access_users_utils.py
@@ -933,7 +933,7 @@ class UserSet(OPNsenseModuleConfig):
             None: This method does not return a value but updates the internal list of users.
         """
 
-        self._users = [r for r in self._users if r != user]
+        self._users = [r for r in self._users if r.name != user.name]
 
     def find(self, **kwargs) -> Optional[User]:
         """


### PR DESCRIPTION
As @GBBx pointed out, the deletion of the user object doesn't work as expected. The reason for this is that the generated `self.users` consists of converted user entries with the `uid` attribute, while the provided user does not have a `uid` attribute.

Since the name attribute of a user is unique, we don't need to compare the entire user object to find the user being deleted.