### PR TITLE
Fix/empty parameter handling

### DIFF
--- a/changelogs/fragments/161-fix-empty-parameters-handling.yml
+++ b/changelogs/fragments/161-fix-empty-parameters-handling.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - puzzle.opnsense.system_access_users - Thanks to @GBBx fixed a bug which falsely adds empty parameters to user instance.

--- a/plugins/module_utils/system_access_users_utils.py
+++ b/plugins/module_utils/system_access_users_utils.py
@@ -558,8 +558,9 @@ class User:
 
         if params.get("groups", None):
             user_dict["groupname"] = params["groups"]
+
         user_dict = {
-            key: value for key, value in user_dict.items() if value is not None
+            key: value for key, value in user_dict.items() if value not in (None, "")
         }
 
         return cls(**user_dict)

--- a/tests/unit/plugins/module_utils/test_system_access_users_utils.py
+++ b/tests/unit/plugins/module_utils/test_system_access_users_utils.py
@@ -994,8 +994,8 @@ def test_user_from_ansible_module_params_with_empty_parameters(
     }
     new_test_user: User = User.from_ansible_module_params(test_params)
 
-    assert new_test_user.shell is None
-    assert new_test_user.email is None
+    assert not hasattr(new_test_user, "shell")
+    assert not hasattr(new_test_user, "email")
 
 
 @patch(


### PR DESCRIPTION
As @GBBx pointed out, empty string parameters were incorrectly added to the user instance, and thus to the config. I've updated the method for checking parameters from Ansible before adding them to the user instance.