### PR TITLE
ci(support-matrix): drop ansible-core <2.18, add 2.18/2.19/2.20, raise Python minimum to 3.11

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -60,11 +60,9 @@ jobs:
           # - stable-2.9 # Only if your collection supports Ansible 2.9
           # - stable-2.10 # Only if your collection supports ansible-base 2.10
           # - stable-2.11 # Only if your collection supports ansible-core 2.11
-          - stable-2.12
-          - stable-2.13
-          - stable-2.14
-          - stable-2.15
-          - stable-2.16
+          - stable-2.18
+          - stable-2.19
+          - stable-2.20
           - devel
         # - milestone
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
@@ -123,11 +121,9 @@ jobs:
           # - stable-2.9 # Only if your collection supports Ansible 2.9
           # - stable-2.10 # Only if your collection supports ansible-base 2.10
           # - stable-2.11 # Only if your collection supports ansible-core 2.11
-          - stable-2.12
-          - stable-2.13
-          - stable-2.14
-          - stable-2.15
-          - stable-2.16
+          - stable-2.18
+          - stable-2.19
+          - stable-2.20
           - devel
         # - milestone
 
@@ -181,40 +177,16 @@ jobs:
           # - stable-2.9 # Only if your collection supports Ansible 2.9
           # - stable-2.10 # Only if your collection supports ansible-base 2.10
           # - stable-2.11 # Only if your collection supports ansible-core 2.11
-          - stable-2.12
-          - stable-2.13
-          - stable-2.14
+          - stable-2.18
+          - stable-2.19
+          - stable-2.20
           - devel
         # - milestone
         python:
-          - '3.8'
-          - '3.9'
-          - '3.10'
           - '3.11'
           - '3.12'
-        exclude:
-          # Because ansible-test doesn't support Python 3.9 for Ansible 2.9
-          - ansible: stable-2.9
-            python: '3.9'
-          # and Python 3.10 is only supported in 2.12 or later.
-          - ansible: stable-2.9
-            python: '3.10'
-          - ansible: stable-2.10
-            python: '3.10'
-          - ansible: stable-2.11
-            python: '3.10'
-          - ansible: stable-2.12
-            python: '3.11'
-          - ansible: stable-2.12
-            python: '3.12'
-          - ansible: stable-2.13
-            python: '3.11'
-          - ansible: stable-2.13
-            python: '3.12'
-          - ansible: stable-2.14
-            python: '3.12'
-          - ansible: devel
-            python: '3.8'
+          - '3.13'
+          - '3.14'
 
 
     steps:

--- a/Pipfile
+++ b/Pipfile
@@ -3,6 +3,9 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 name = "pypi"
 
+[requires]
+python_version = "3.11"
+
 [packages]
 ansible = "==12.1.0"
 molecule = "25.9.0"

--- a/changelogs/fragments/drop-python-3.10-ansible-2.14.yml
+++ b/changelogs/fragments/drop-python-3.10-ansible-2.14.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - ci - raise minimum Python to 3.11 and drop ansible-core <2.18 support; add ansible-core 2.18/2.19/2.20 and Python 3.13/3.14 to CI matrix

--- a/docs/docsite/rst/development_guide.rst
+++ b/docs/docsite/rst/development_guide.rst
@@ -34,7 +34,7 @@ Ansible documentation (`Prepare your environment
     git clone git@github.com/<YOUR_GITHUB_HANDLE>/puzzle.opnsense.git \
        <YOUR_WORKING_DIR>/ansible_collections/puzzle/opnsense
 
-3. This collection supports Python versions >=3.8,<3.12 therefore make sure your system
+3. This collection supports Python versions >=3.11 therefore make sure your system
    supports any of those versions.
 4. Setup the pipenv:
 

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,4 +1,4 @@
 ---
 # ansible-test configurations
 modules:
-  python_requires: ">=3.8"
+  python_requires: ">=3.11"


### PR DESCRIPTION
## Summary

**Supersedes #195**

Drops support for ansible-core <2.18 and raises the minimum Python version to 3.11 on the control node, aligning with the [ansible-core support matrix](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html) where 2.18+ supports Python 3.11–3.14.

## Changes
- `.github/workflows/ansible-test.yml`:
  - Replace `stable-2.15`, `stable-2.16` with `stable-2.18`, `stable-2.19`, `stable-2.20` across sanity, units, and integration matrices
  - Add Python `3.13` and `3.14` to the integration matrix
- `tests/config.yml`: `python_requires: ">=3.11"`
- `docs/docsite/rst/development_guide.rst`: update Python version string
- `Pipfile`: add `[requires] python_version = "3.11"`

⚠️ After merge: run `pipenv lock` on Python 3.11 to regenerate `Pipfile.lock`.

## Merge order
**Must merge first** — subsequent MRs depend on CI running against the new matrix.