### PR TITLE
feat(module_index): add OPNsense 26.1 support, drop 24.1

### DIFF
--- a/changelogs/fragments/add-26.1-support.yml
+++ b/changelogs/fragments/add-26.1-support.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - module_index - add OPNsense 26.1 to VERSION_MAP for interfaces_assignments and system_settings_general
+  - module_index - drop OPNsense 24.1 from VERSION_MAP

--- a/changelogs/fragments/add-26.1-support.yml
+++ b/changelogs/fragments/add-26.1-support.yml
@@ -1,3 +1,4 @@
 minor_changes:
   - module_index - add OPNsense 26.1 to VERSION_MAP for interfaces_assignments and system_settings_general
+breaking_changes:
   - module_index - drop OPNsense 24.1 from VERSION_MAP

--- a/molecule/opnsense_config/molecule.yml
+++ b/molecule/opnsense_config/molecule.yml
@@ -16,16 +16,6 @@ driver:
     parallel: true
 
 platforms:
-    - name: "24.1"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "24.1"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-          - 'vm.guest = :freebsd'
-          - 'ssh.sudo_command = "%c"'
-          - 'ssh.shell = "/bin/sh"'
     - name: "24.7"
       box: puzzle/opnsense
       hostname: false
@@ -50,6 +40,16 @@ platforms:
       box: puzzle/opnsense
       hostname: false
       box_version: "25.7"
+      memory: 1024
+      cpus: 2
+      instance_raw_config_args:
+          - 'vm.guest = :freebsd'
+          - 'ssh.sudo_command = "%c"'
+          - 'ssh.shell = "/bin/sh"'
+    - name: "26.1"
+      box: puzzle/opnsense
+      hostname: false
+      box_version: "26.1"
       memory: 1024
       cpus: 2
       instance_raw_config_args:

--- a/plugins/module_utils/module_index.py
+++ b/plugins/module_utils/module_index.py
@@ -29,160 +29,6 @@ provides a centralized definition for various configurations across different OP
 """
 # pylint: disable=duplicate-code; Since this is rewritten in some tests.
 VERSION_MAP = {
-    "24.1": {
-        "system_settings_general": {
-            "hostname": "system/hostname",
-            "domain": "system/domain",
-            "timezone": "system/timezone",
-            # Add other mappings here
-            "php_requirements": [
-                "/usr/local/etc/inc/config.inc",
-                "/usr/local/etc/inc/util.inc",
-                "/usr/local/etc/inc/filter.inc",
-                "/usr/local/etc/inc/system.inc",
-                "/usr/local/etc/inc/interfaces.inc",
-            ],
-            "configure_functions": {
-                "system_timezone_configure": {
-                    "name": "system_timezone_configure",
-                    "configure_params": ["true"],
-                },
-                "system_trust_configure": {
-                    "name": "system_trust_configure",
-                    "configure_params": ["true"],
-                },
-                "system_hostname_configure": {
-                    "name": "system_hostname_configure",
-                    "configure_params": ["true"],
-                },
-                "system_hosts_generate": {
-                    "name": "system_hosts_generate",
-                    "configure_params": ["true"],
-                },
-                "system_resolvconf_generate": {
-                    "name": "system_resolvconf_generate",
-                    "configure_params": ["true"],
-                },
-                "plugins_configure_dns": {
-                    "name": "plugins_configure",
-                    "configure_params": ["'dns'", "true"],
-                },
-                "plugins_configure_dhcp": {
-                    "name": "plugins_configure",
-                    "configure_params": ["'dhcp'", "true"],
-                },
-                "filter_configure": {
-                    "name": "filter_configure",
-                    "configure_params": ["true"],
-                },
-            },
-        },
-        "system_settings_logging": {
-            "preserve_logs": "syslog/preservelogs",
-            "max_log_file_size_mb": "syslog/maxfilesize",
-            # Add other mappings here
-            "php_requirements": [
-                "/usr/local/etc/inc/config.inc",
-                "/usr/local/etc/inc/util.inc",
-                "/usr/local/etc/inc/system.inc",
-            ],
-            "configure_functions": {
-                "system_settings_logging": {
-                    "name": "system_syslog_start",
-                    "configure_params": ["true"],
-                }
-            },
-        },
-        "system_access_users": {
-            "users": "system/user",
-            "uid": "system/nextuid",
-            "gid": "system/nextgid",
-            "system": "system",
-            "maximumtableentries": "system/maximumtableentries",
-            "php_requirements": [
-                "/usr/local/etc/inc/system.inc",
-            ],
-            "configure_functions": {},
-        },
-        "password": {
-            "php_requirements": [
-                "/usr/local/etc/inc/auth.inc",
-            ],
-            "configure_functions": {
-                "password": {
-                    "name": "echo password_hash",
-                    "configure_params": [
-                        "'password'",
-                        "PASSWORD_BCRYPT",
-                        "[ 'cost' => 11 ]",
-                    ],
-                },
-            },
-        },
-        "firewall_rules": {
-            "rules": "filter",
-            "php_requirements": [
-                "/usr/local/etc/inc/interfaces.inc",
-                "/usr/local/etc/inc/config.inc",
-                "/usr/local/etc/inc/util.inc",
-                "/usr/local/etc/inc/system.inc",
-                "/usr/local/etc/inc/filter.inc",
-            ],
-            "configure_functions": {
-                "system_cron_configure": {
-                    "name": "system_cron_configure",
-                    "configure_params": ["true"],
-                },
-                "filter_configure": {
-                    "name": "filter_configure",
-                    "configure_params": [],
-                },
-            },
-        },
-        "interfaces_assignments": {
-            "interfaces": "interfaces",
-            # Add other mappings here.
-            "php_requirements": [
-                "/usr/local/etc/inc/config.inc",
-                "/usr/local/etc/inc/util.inc",
-                "/usr/local/etc/inc/filter.inc",
-                "/usr/local/etc/inc/system.inc",
-                "/usr/local/etc/inc/rrd.inc",
-                "/usr/local/etc/inc/interfaces.inc",
-            ],
-            "configure_functions": {
-                "filter_configure": {
-                    "name": "filter_configure",
-                    "configure_params": [],
-                },
-            },
-        },
-        "system_high_availability_settings": {
-            # Add other mappings here
-            "hasync": "hasync",
-            "synchronize_states": "hasync/pfsyncenabled",
-            "synchronize_interface": "hasync/pfsyncinterface",
-            "synchronize_peer_ip": "hasync/pfsyncpeerip",
-            "synchronize_config_to_ip": "hasync/synchronizetoip",
-            "remote_system_username": "hasync/username",
-            "remote_system_password": "hasync/password",
-            "disable_preempt": "hasync/disablepreempt",
-            "disconnect_dialup_interfaces": "hasync/disconnectppps",
-            "php_requirements": [
-                "/usr/local/etc/inc/interfaces.inc",
-                "/usr/local/etc/inc/util.inc",
-                "/usr/local/etc/inc/config.inc",
-                "/usr/local/etc/inc/plugins.inc",
-            ],
-            "configure_functions": {},
-        },
-        "firewall_alias": {
-            "alias": "OPNsense/Firewall/Alias/aliases",
-            "geoip": "OPNsense/Firewall/Alias/geoip",
-            "php_requirements": [],
-            "configure_functions": {},
-        },
-    },
     "24.7": {
         "system_settings_general": {
             "hostname": "system/hostname",
@@ -231,68 +77,6 @@ VERSION_MAP = {
                 },
             },
         },
-        "system_settings_logging": {
-            "preserve_logs": ".//Syslog/general/maxpreserve",
-            "max_log_file_size_mb": ".//Syslog/general/maxfilesize",
-            # Add other mappings here
-            "php_requirements": [
-                "/usr/local/etc/inc/config.inc",
-                "/usr/local/etc/inc/util.inc",
-                "/usr/local/etc/inc/system.inc",
-            ],
-            "configure_functions": {
-                "system_settings_logging": {
-                    "name": "system_syslog_start",
-                    "configure_params": ["true"],
-                }
-            },
-        },
-        "system_access_users": {
-            "users": "system/user",
-            "uid": "system/nextuid",
-            "gid": "system/nextgid",
-            "system": "system",
-            "maximumtableentries": "system/maximumtableentries",
-            "php_requirements": [
-                "/usr/local/etc/inc/system.inc",
-            ],
-            "configure_functions": {},
-        },
-        "password": {
-            "php_requirements": [
-                "/usr/local/etc/inc/auth.inc",
-            ],
-            "configure_functions": {
-                "password": {
-                    "name": "echo password_hash",
-                    "configure_params": [
-                        "'password'",
-                        "PASSWORD_BCRYPT",
-                        "[ 'cost' => 11 ]",
-                    ],
-                },
-            },
-        },
-        "firewall_rules": {
-            "rules": "filter",
-            "php_requirements": [
-                "/usr/local/etc/inc/interfaces.inc",
-                "/usr/local/etc/inc/config.inc",
-                "/usr/local/etc/inc/util.inc",
-                "/usr/local/etc/inc/system.inc",
-                "/usr/local/etc/inc/filter.inc",
-            ],
-            "configure_functions": {
-                "system_cron_configure": {
-                    "name": "system_cron_configure",
-                    "configure_params": ["true"],
-                },
-                "filter_configure": {
-                    "name": "filter_configure",
-                    "configure_params": [],
-                },
-            },
-        },
         "interfaces_assignments": {
             "interfaces": "interfaces",
             # Add other mappings here.
@@ -310,33 +94,6 @@ VERSION_MAP = {
                     "configure_params": [],
                 },
             },
-        },
-        "system_high_availability_settings": {
-            # Add other mappings here
-            "hasync": "hasync",
-            "synchronize_states": "hasync/pfsyncenabled",
-            "synchronize_interface": "hasync/pfsyncinterface",
-            "synchronize_peer_ip": "hasync/pfsyncpeerip",
-            "synchronize_config_to_ip": "hasync/synchronizetoip",
-            "remote_system_username": "hasync/username",
-            "sync_compatibility": "hasync/pfsyncversion",
-            "remote_system_password": "hasync/password",
-            "disable_preempt": "hasync/disablepreempt",
-            "disconnect_dialup_interfaces": "hasync/disconnectppps",
-            "sync_services": "hasync/syncitems",
-            "php_requirements": [
-                "/usr/local/etc/inc/interfaces.inc",
-                "/usr/local/etc/inc/util.inc",
-                "/usr/local/etc/inc/config.inc",
-                "/usr/local/etc/inc/plugins.inc",
-            ],
-            "configure_functions": {},
-        },
-        "firewall_alias": {
-            "alias": "OPNsense/Firewall/Alias/aliases",
-            "geoip": "OPNsense/Firewall/Alias/geoip",
-            "php_requirements": [],
-            "configure_functions": {},
         },
     },
     "25.1": {
@@ -386,26 +143,6 @@ VERSION_MAP = {
                     "configure_params": ["true"],
                 },
             },
-        },
-        "system_high_availability_settings": {
-            "hasync": "hasync",
-            "synchronize_states": "hasync/pfsyncenabled",
-            "synchronize_interface": "hasync/pfsyncinterface",
-            "synchronize_peer_ip": "hasync/pfsyncpeerip",
-            "synchronize_config_to_ip": "hasync/synchronizetoip",
-            "remote_system_username": "hasync/username",
-            "sync_compatibility": "hasync/pfsyncversion",
-            "remote_system_password": "hasync/password",
-            "disable_preempt": "hasync/disablepreempt",
-            "disconnect_dialup_interfaces": "hasync/disconnectppps",
-            "sync_services": "hasync/syncitems",
-            "php_requirements": [
-                "/usr/local/etc/inc/interfaces.inc",
-                "/usr/local/etc/inc/util.inc",
-                "/usr/local/etc/inc/config.inc",
-                "/usr/local/etc/inc/plugins.inc",
-            ],
-            "configure_functions": {},
         },
         "interfaces_assignments": {
             "interfaces": "interfaces",
@@ -458,6 +195,65 @@ VERSION_MAP = {
                 },
                 "system_resolvconf_generate": {
                     "name": "system_resolvconf_generate",
+                    "configure_params": ["true"],
+                },
+                "plugins_configure_dns": {
+                    "name": "plugins_configure",
+                    "configure_params": ["'dns'", "true"],
+                },
+                "plugins_configure_dhcp": {
+                    "name": "plugins_configure",
+                    "configure_params": ["'dhcp'", "true"],
+                },
+                "filter_configure": {
+                    "name": "filter_configure",
+                    "configure_params": ["true"],
+                },
+            },
+        },
+        "interfaces_assignments": {
+            "interfaces": "interfaces",
+            # Add other mappings here.
+            "php_requirements": [
+                "/usr/local/etc/inc/config.inc",
+                "/usr/local/etc/inc/util.inc",
+                "/usr/local/etc/inc/filter.inc",
+                "/usr/local/etc/inc/system.inc",
+                "/usr/local/etc/inc/rrd.inc",
+                "/usr/local/etc/inc/interfaces.inc",
+            ],
+            "configure_functions": {
+                "filter_configure": {
+                    "name": "filter_configure",
+                    "configure_params": [],
+                },
+            },
+        },
+    },
+    "26.1": {
+        "system_settings_general": {
+            "hostname": "system/hostname",
+            "domain": "system/domain",
+            "timezone": "system/timezone",
+            # Add other mappings here
+            "php_requirements": [
+                "/usr/local/etc/inc/config.inc",
+                "/usr/local/etc/inc/util.inc",
+                "/usr/local/etc/inc/filter.inc",
+                "/usr/local/etc/inc/system.inc",
+                "/usr/local/etc/inc/interfaces.inc",
+            ],
+            "configure_functions": {
+                "system_timezone_configure": {
+                    "name": "system_timezone_configure",
+                    "configure_params": ["true"],
+                },
+                "system_hostname_configure": {
+                    "name": "system_hostname_configure",
+                    "configure_params": ["true"],
+                },
+                "system_resolver_configure": {
+                    "name": "system_resolver_configure",
                     "configure_params": ["true"],
                 },
                 "plugins_configure_dns": {


### PR DESCRIPTION
## Summary

**Supersedes #195**

Adds OPNsense 26.1 to `VERSION_MAP` and drops the now-unsupported 24.1 entry. Updates the `opnsense_config` molecule scenario.

## Changes
- `plugins/module_utils/module_index.py`: remove `"24.1"` key; add `"26.1"` key for `system_settings_general` and `interfaces_assignments`
  - `system_settings_general` 26.1: `system_resolver_configure` replaces `system_trust_configure` + `system_hosts_generate` + `system_resolvconf_generate`
  - `interfaces_assignments` 26.1: identical to 25.7 (upstream `interfaces_assign.php` unchanged)
- `molecule/opnsense_config/molecule.yml`: remove `24.1` platform, add `26.1` platform

## Merge order
Merge after MR #199 (ci/support-matrix). The `chore/deprecate-*` MRs can be opened in parallel once this is merged.