### PR TITLE
fix(interfaces_assignments): add 26.1 molecule platform, remove 24.1

### DIFF
--- a/changelogs/fragments/interfaces-assignments-26.1.yml
+++ b/changelogs/fragments/interfaces-assignments-26.1.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - interfaces_assignments - add OPNsense 26.1 molecule platform, remove 24.1

--- a/molecule/interfaces_assignments/molecule.yml
+++ b/molecule/interfaces_assignments/molecule.yml
@@ -16,16 +16,6 @@ driver:
     parallel: true
 
 platforms:
-    - name: "24.1"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "24.1"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-        - 'vm.guest = :freebsd'
-        - 'ssh.sudo_command = "%c"'
-        - 'ssh.shell = "/bin/sh"'
     - name: "24.7"
       box: puzzle/opnsense
       hostname: false
@@ -50,6 +40,16 @@ platforms:
       box: puzzle/opnsense
       hostname: false
       box_version: "25.7"
+      memory: 1024
+      cpus: 2
+      instance_raw_config_args:
+        - 'vm.guest = :freebsd'
+        - 'ssh.sudo_command = "%c"'
+        - 'ssh.shell = "/bin/sh"'
+    - name: "26.1"
+      box: puzzle/opnsense
+      hostname: false
+      box_version: "26.1"
       memory: 1024
       cpus: 2
       instance_raw_config_args:


### PR DESCRIPTION
## Summary

**Supersedes #195**

Updates the `interfaces_assignments` molecule scenario to test against OPNsense 26.1 and removes the dropped 24.1 platform.

## Changes
- `molecule/interfaces_assignments/molecule.yml`: remove `24.1` platform block, add `26.1` platform block

## Notes
Upstream `interfaces_assign.php` is unchanged in 26.1 — no `module_index.py` changes needed for this module.

## Merge order
Merge after MR #200 (`feat/opnsense-26.1-support`).