### PR TITLE
fix(system_settings_general): add 26.1 molecule platform, remove 24.1

### DIFF
--- a/changelogs/fragments/system-settings-general-26.1.yml
+++ b/changelogs/fragments/system-settings-general-26.1.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - system_settings_general - update configure functions for OPNsense 26.1 (system_resolver_configure replaces system_trust_configure/system_hosts_generate/system_resolvconf_generate); add 26.1 molecule platform, remove 24.1

--- a/molecule/system_settings_general/molecule.yml
+++ b/molecule/system_settings_general/molecule.yml
@@ -16,16 +16,6 @@ driver:
     parallel: true
 
 platforms:
-    - name: "24.1"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "24.1"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-        - 'vm.guest = :freebsd'
-        - 'ssh.sudo_command = "%c"'
-        - 'ssh.shell = "/bin/sh"'
     - name: "24.7"
       box: puzzle/opnsense
       hostname: false
@@ -40,6 +30,26 @@ platforms:
       box: puzzle/opnsense
       hostname: false
       box_version: "25.1"
+      memory: 1024
+      cpus: 2
+      instance_raw_config_args:
+        - 'vm.guest = :freebsd'
+        - 'ssh.sudo_command = "%c"'
+        - 'ssh.shell = "/bin/sh"'
+    - name: "25.7"
+      box: puzzle/opnsense
+      hostname: false
+      box_version: "25.7"
+      memory: 1024
+      cpus: 2
+      instance_raw_config_args:
+        - 'vm.guest = :freebsd'
+        - 'ssh.sudo_command = "%c"'
+        - 'ssh.shell = "/bin/sh"'
+    - name: "26.1"
+      box: puzzle/opnsense
+      hostname: false
+      box_version: "26.1"
       memory: 1024
       cpus: 2
       instance_raw_config_args:


### PR DESCRIPTION
## Summary

**Supersedes #195**

Updates the `system_settings_general` molecule scenario to test against OPNsense 25.7 and 26.1, and removes the dropped 24.1 platform.

## Changes
- `molecule/system_settings_general/molecule.yml`: remove `24.1` platform block, add `25.7` and `26.1` platform blocks

## Notes
The 26.1 configure-function change (`system_resolver_configure` replacing the three legacy functions) is already covered in MR #200 (`feat/opnsense-26.1-support`).

## Merge order
Merge after MR #200 (`feat/opnsense-26.1-support`).