### PR TITLE
refactor(molecule): migrate from molecule-plugins to ansible-native driver

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -55,25 +55,12 @@ jobs:
           # around creation of a new stable branch, this might cause a problem
           # that two different versions of ansible-test use the same sanity test
           # ignore.txt file.
-          # The commented branches below are EOL,
-          # do you really need your collection to support them if it still does?
-          # - stable-2.9 # Only if your collection supports Ansible 2.9
-          # - stable-2.10 # Only if your collection supports ansible-base 2.10
-          # - stable-2.11 # Only if your collection supports ansible-core 2.11
           - stable-2.18
           - stable-2.19
           - stable-2.20
           - devel
         # - milestone
-    # Ansible-test on various stable branches does not yet work well with cgroups v2.
-    # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
-    # image for these stable branches. The list of branches where this is necessary will
-    # shrink over time, check out https://github.com/ansible-collections/news-for-maintainers/issues/28
-    # for the latest list.
-    runs-on: >-
-      ${{ contains(fromJson(
-          '["stable-2.9", "stable-2.10", "stable-2.11"]'
-      ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       # Run sanity tests inside a Docker container.
       # The docker container has all the pinned dependencies that are
@@ -101,26 +88,13 @@ jobs:
 # https://docs.ansible.com/ansible/latest/dev_guide/testing_units.html
 
   units:
-    # Ansible-test on various stable branches does not yet work well with cgroups v2.
-    # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
-    # image for these stable branches. The list of branches where this is necessary will
-    # shrink over time, check out https://github.com/ansible-collections/news-for-maintainers/issues/28
-    # for the latest list.
-    runs-on: >-
-      ${{ contains(fromJson(
-          '["stable-2.9", "stable-2.10", "stable-2.11"]'
-      ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     name: Units (Ⓐ${{ matrix.ansible }})
     strategy:
       # As soon as the first unit test fails, cancel the others to free up the CI queue
       fail-fast: true
       matrix:
         ansible:
-          # The commented branches below are EOL,
-          # do you really need your collection to support them if it still does?
-          # - stable-2.9 # Only if your collection supports Ansible 2.9
-          # - stable-2.10 # Only if your collection supports ansible-base 2.10
-          # - stable-2.11 # Only if your collection supports ansible-core 2.11
           - stable-2.18
           - stable-2.19
           - stable-2.20
@@ -158,30 +132,16 @@ jobs:
 # https://github.com/ansible-collections/community.zabbix/tree/master/.github/workflows
 
   integration:
-    # Ansible-test on various stable branches does not yet work well with cgroups v2.
-    # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
-    # image for these stable branches. The list of branches where this is necessary will
-    # shrink over time, check out https://github.com/ansible-collections/news-for-maintainers/issues/28
-    # for the latest list.
-    runs-on: >-
-      ${{ contains(fromJson(
-          '["stable-2.9", "stable-2.10", "stable-2.11"]'
-      ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     name: I (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
     strategy:
       fail-fast: false
       matrix:
         ansible:
-          # The commented branches below are EOL,
-          # do you really need your collection to support them if it still does?
-          # - stable-2.9 # Only if your collection supports Ansible 2.9
-          # - stable-2.10 # Only if your collection supports ansible-base 2.10
-          # - stable-2.11 # Only if your collection supports ansible-core 2.11
           - stable-2.18
           - stable-2.19
           - stable-2.20
           - devel
-        # - milestone
         python:
           - '3.11'
           - '3.12'
@@ -192,6 +152,10 @@ jobs:
             python: '3.14'
           - ansible: stable-2.19
             python: '3.14'
+          # `devel` typically drops the oldest control-node Python before stable does.
+          - ansible: devel
+            python: '3.11'
+
 
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install Python dependencies
         run: |

--- a/Pipfile
+++ b/Pipfile
@@ -8,16 +8,13 @@ python_version = "3.13"
 
 [packages]
 ansible = "==13.6.0"
-molecule = "26.4.0"
 antsibull-docs = "==2.24.0"
+antsibull-changelog = "==0.35.0"
+black = "==26.3.1"
+coverage = "==7.6.1"
+molecule = "26.4.0"
 pytest = "==9.0.3"
 pytest-forked = "==1.6.0"
 pytest-xdist = "==3.8.0"
 pyyaml = "==6.0.3"
 pylint = "==4.0.5"
-black = "==26.3.1"
-antsibull-changelog = "==0.35.0"
-molecule-plugins = {extras = ["vagrant"], version = "==25.8.12"}
-coverage = "==7.6.1"
-
-[dev-packages]

--- a/Pipfile
+++ b/Pipfile
@@ -4,19 +4,19 @@ verify_ssl = true
 name = "pypi"
 
 [requires]
-python_version = "3.11"
+python_version = "3.13"
 
 [packages]
-ansible = "==12.1.0"
-molecule = "25.9.0"
-antsibull-docs = "==2.22.0"
-pytest = "==8.4.2"
+ansible = "==13.6.0"
+molecule = "26.4.0"
+antsibull-docs = "==2.24.0"
+pytest = "==9.0.3"
 pytest-forked = "==1.6.0"
 pytest-xdist = "==3.8.0"
 pyyaml = "==6.0.3"
-pylint = "==4.0.2"
-black = "==25.9.0"
-antsibull-changelog = "==0.34.0"
+pylint = "==4.0.5"
+black = "==26.3.1"
+antsibull-changelog = "==0.35.0"
 molecule-plugins = {extras = ["vagrant"], version = "==25.8.12"}
 coverage = "==7.6.1"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,23 @@
 {
     "_meta": {
         "hash": {
+<<<<<<< Updated upstream
             "sha256": "b0ffa1f26f2aa5db25abf06c0c2fec3318e9e94ccaf41f11623d25ef97c46167"
         },
         "pipfile-spec": 6,
         "requires": {
             "python_version": "3.13"
+=======
+<<<<<<< Updated upstream
+            "sha256": "043b9f5041bb1d4ae3c23a9b89d994a292efed8693c5c5e92bdbad78a01f8cf3"
+=======
+            "sha256": "3464c6e1c650e793b5caba54a53636ff0825d1a5bc1be96d9fe1690154af6b28"
+>>>>>>> Stashed changes
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.11"
+>>>>>>> Stashed changes
         },
         "sources": [
             {
@@ -1081,17 +1093,6 @@
             "markers": "python_version >= '3.10'",
             "version": "==26.4.0"
         },
-        "molecule-plugins": {
-            "extras": [
-                "vagrant"
-            ],
-            "hashes": [
-                "sha256:75f32763e90275bfc24bcc0d27b9bb22ac973658bf902b2e3e8af8e2a1c32083",
-                "sha256:c5b8ceb209a5ff87326631d60408f8d08b9431b2e339dad4c620130b50279ce0"
-            ],
-            "markers": "python_version >= '3.10'",
-            "version": "==25.8.12"
-        },
         "multidict": {
             "hashes": [
                 "sha256:026d264228bcd637d4e060844e39cdc60f86c479e463d49075dedc21b18fbbe0",
@@ -1621,14 +1622,6 @@
             "markers": "python_version >= '3.9'",
             "version": "==3.8.0"
         },
-        "python-vagrant": {
-            "hashes": [
-                "sha256:9f24a29e3f7b17d79c399d0f358d9cc1b76fd5495698c438a39cdae89de467f0",
-                "sha256:a8fe93ccf2ff37ecc95ec2f49ea74a91a6ce73a4db4a16a98dd26d397cfd09e5"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.0.0"
-        },
         "pytokens": {
             "hashes": [
                 "sha256:0fc71786e629cef478cbf29d7ea1923299181d0699dbe7c3c0f4a583811d9fc1",
@@ -1789,6 +1782,7 @@
             "markers": "python_full_version >= '3.9.0'",
             "version": "==15.0.0"
         },
+<<<<<<< Updated upstream
         "roman-numerals": {
             "hashes": [
                 "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2",
@@ -1797,6 +1791,8 @@
             "markers": "python_version >= '3.10'",
             "version": "==4.1.0"
         },
+=======
+>>>>>>> Stashed changes
         "rpds-py": {
             "hashes": [
                 "sha256:01d17b29c0c23d82b1f4751147ec49cf451f1fc2554eb9ef5f957e55d2656ead",

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ba76fa0cffe1bafc4bb571d40abf81f173529b1d9cabd23bb3df1cb0d5d64eab"
+            "sha256": "b0ffa1f26f2aa5db25abf06c0c2fec3318e9e94ccaf41f11623d25ef97c46167"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.11"
+            "python_version": "3.13"
         },
         "sources": [
             {
@@ -26,137 +26,136 @@
         },
         "aiohappyeyeballs": {
             "hashes": [
-                "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558",
-                "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8"
+                "sha256:4708045e2d7a6c6bdf8aafa8ed39649eaf926a4543b54560659129e3365953c4",
+                "sha256:e202810ee718bd01fc6ef49e8ea53d023d5cb6b581076d7925aa499fa55dbe64"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.6.1"
+            "markers": "python_version >= '3.10'",
+            "version": "==2.6.2"
         },
         "aiohttp": {
             "hashes": [
-                "sha256:019a67772e034a0e6b9b17c13d0a8fe56ad9fb150fc724b7f3ffd3724288d9e5",
-                "sha256:02222e7e233295f40e011c1b00e3b0bd451f22cf853a0304c3595633ee47da4b",
-                "sha256:023ecba036ddd840b0b19bf195bfae970083fd7024ce1ac22e9bba90464620e9",
-                "sha256:02e048037a6501a5ec1f6fc9736135aec6eb8a004ce48838cb951c515f32c80b",
-                "sha256:0494a01ca9584eea1e5fbd6d748e61ecff218c51b576ee1999c23db7066417d8",
-                "sha256:0f7a18f258d124cd678c5fe072fe4432a4d5232b0657fca7c1847f599233c83a",
-                "sha256:10a75acfcf794edf9d8db50e5a7ec5fc818b2a8d3f591ce93bc7b1210df016d2",
-                "sha256:110e448e02c729bcebb18c60b9214a87ba33bac4a9fa5e9a5f139938b56c6cb1",
-                "sha256:147b4f501d0292077f29d5268c16bb7c864a1f054d7001c4c1812c0421ea1ed0",
-                "sha256:157826e2fa245d2ef46c83ea8a5faf77ca19355d278d425c29fda0beb3318037",
-                "sha256:15c933ad7920b7d9a20de151efcd05a6e38302cbf0e10c9b2acb9a42210a2416",
-                "sha256:178c7b5e62b454c2bc790786e6058c3cc968613b4419251b478c153a4aec32b1",
-                "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9",
-                "sha256:1efb06900858bb618ff5cee184ae2de5828896c448403d51fb633f09e109be0a",
-                "sha256:20058e23909b9e65f9da62b396b77dfa95965cbe840f8def6e572538b1d32e36",
-                "sha256:206b7b3ef96e4ce211754f0cd003feb28b7d81f0ad26b8d077a5d5161436067f",
-                "sha256:20ae0ff08b1f2c8788d6fb85afcb798654ae6ba0b747575f8562de738078457b",
-                "sha256:2294172ce08a82fb7c7273485895de1fa1186cc8294cfeb6aef4af42ad261174",
-                "sha256:241a94f7de7c0c3b616627aaad530fe2cb620084a8b144d3be7b6ecfe95bae3b",
-                "sha256:26d2f8546f1dfa75efa50c3488215a903c0168d253b75fba4210f57ab77a0fb8",
-                "sha256:2837fb92951564d6339cedae4a7231692aa9f73cbc4fb2e04263b96844e03b4e",
-                "sha256:2994be9f6e51046c4f864598fd9abeb4fba6e88f0b2152422c9666dcd4aea9c6",
-                "sha256:2d6d44a5b48132053c2f6cd5c8cb14bc67e99a63594e336b0f2af81e94d5530c",
-                "sha256:31cebae8b26f8a615d2b546fee45d5ffb76852ae6450e2a03f42c9102260d6fe",
-                "sha256:327cc432fdf1356fb4fbc6fe833ad4e9f6aacb71a8acaa5f1855e4b25910e4a9",
-                "sha256:329f292ed14d38a6c4c435e465f48bebb47479fd676a0411936cc371643225cc",
-                "sha256:330f5da04c987f1d5bdb8ae189137c77139f36bd1cb23779ca1a354a4b027800",
-                "sha256:33add2463dde55c4f2d9635c6ab33ce154e5ecf322bd26d09af95c5f81cfa286",
-                "sha256:347542f0ea3f95b2a955ee6656461fa1c776e401ac50ebce055a6c38454a0adf",
-                "sha256:39380e12bd1f2fdab4285b6e055ad48efbaed5c836433b142ed4f5b9be71036a",
-                "sha256:3a807cabd5115fb55af198b98178997a5e0e57dead43eb74a93d9c07d6d4a7dc",
-                "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9",
-                "sha256:3df334e39d4c2f899a914f1dba283c1aadc311790733f705182998c6f7cae665",
-                "sha256:4bb6bf5811620003614076bdc807ef3b5e38244f9d25ca5fe888eaccea2a9832",
-                "sha256:4beac52e9fe46d6abf98b0176a88154b742e878fdf209d2248e99fcdf73cd297",
-                "sha256:4e704c52438f66fdd89588346183d898bb42167cf88f8b7ff1c0f9fc957c348f",
-                "sha256:4eac02d9af4813ee289cd63a361576da36dba57f5a1ab36377bc2600db0cbb73",
-                "sha256:53fc049ed6390d05423ba33103ded7281fe897cf97878f369a527070bd95795b",
-                "sha256:55b3bdd3292283295774ab585160c4004f4f2f203946997f49aac032c84649e9",
-                "sha256:57653eac22c6a4c13eb22ecf4d673d64a12f266e72785ab1c8b8e5940d0e8090",
-                "sha256:60869c7ac4aaabe7110f26499f3e6e5696eae98144735b12a9c3d9eae2b51a49",
-                "sha256:636bc362f0c5bbc7372bc3ae49737f9e3030dbce469f0f422c8f38079780363d",
-                "sha256:676e5651705ad5d8a70aeb8eb6936c436d8ebbd56e63436cb7dd9bb36d2a9a46",
-                "sha256:69f571de7500e0557801c0b51f4780482c0ec5fe2ac851af5a92cfce1af1cb83",
-                "sha256:6a7cbeb06d1070f1d14895eeeed4dac5913b22d7b456f2eb969f11f4b3993796",
-                "sha256:6cf81fe010b8c17b09495cbd15c1d35afbc8fb405c0c9cf4738e5ae3af1d65be",
-                "sha256:6e27ea05d184afac78aabbac667450c75e54e35f62238d44463131bd3f96753d",
-                "sha256:6f1cbf0c7926d315c3c26c2da41fd2b5d2fe01ac0e157b78caefc51a782196cf",
-                "sha256:6f497a6876aa4b1a102b04996ce4c1170c7040d83faa9387dd921c16e30d5c83",
-                "sha256:756c3c304d394977519824449600adaf2be0ccee76d206ee339c5e76b70ded25",
-                "sha256:77dfa48c9f8013271011e51c00f8ada19851f013cde2c48fca1ba5e0caf5bb06",
-                "sha256:7996023b2ed59489ae4762256c8516df9820f751cf2c5da8ed2fb20ee50abab3",
-                "sha256:7ab7229b6f9b5c1ba4910d6c41a9eb11f543eadb3f384df1b4c293f4e73d44d6",
-                "sha256:7becdf835feff2f4f335d7477f121af787e3504b48b449ff737afb35869ba7bb",
-                "sha256:7c35b0bf0b48a70b4cb4fc5d7bed9b932532728e124874355de1a0af8ec4bc88",
-                "sha256:7c4b6668b2b2b9027f209ddf647f2a4407784b5d88b8be4efcc72036f365baf9",
-                "sha256:7e5dc4311bd5ac493886c63cbf76ab579dbe4641268e7c74e48e774c74b6f2be",
-                "sha256:888e78eb5ca55a615d285c3c09a7a91b42e9dd6fc699b166ebd5dee87c9ccf14",
-                "sha256:898703aa2667e3c5ca4c54ca36cd73f58b7a38ef87a5606414799ebce4d3fd3a",
-                "sha256:8b14eb3262fad0dc2f89c1a43b13727e709504972186ff6a99a3ecaa77102b6c",
-                "sha256:8bd3ec6376e68a41f9f95f5ed170e2fcf22d4eb27a1f8cb361d0508f6e0557f3",
-                "sha256:8cf20a8d6868cb15a73cab329ffc07291ba8c22b1b88176026106ae39aa6df0f",
-                "sha256:8f14c50708bb156b3a3ca7230b3d820199d56a48e3af76fa21c2d6087190fe3d",
-                "sha256:8f546a4dc1e6a5edbb9fd1fd6ad18134550e096a5a43f4ad74acfbd834fc6670",
-                "sha256:912d4b6af530ddb1338a66229dac3a25ff11d4448be3ec3d6340583995f56031",
-                "sha256:9277145d36a01653863899c665243871434694bcc3431922c3b35c978061bdb8",
-                "sha256:95d14ca7abefde230f7639ec136ade282655431fd5db03c343b19dda72dd1643",
-                "sha256:999802d5fa0389f58decd24b537c54aa63c01c3219ce17d1214cbda3c2b22d2d",
-                "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8",
-                "sha256:9b16c653d38eb1a611cc898c41e76859ca27f119d25b53c12875fd0474ae31a8",
-                "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1",
-                "sha256:9efcc0f11d850cefcafdd9275b9576ad3bfb539bed96807663b32ad99c4d4b88",
-                "sha256:a2567b72e1ffc3ab25510db43f355b29eeada56c0a622e58dcdb19530eb0a3cb",
-                "sha256:a5029cc80718bbd545123cd8fe5d15025eccaaaace5d0eeec6bd556ad6163d61",
-                "sha256:a60eaa2d440cd4707696b52e40ed3e2b0f73f65be07fd0ef23b6b539c9c0b0b4",
-                "sha256:a79a6d399cef33a11b6f004c67bb07741d91f2be01b8d712d52c75711b1e07c7",
-                "sha256:a84792f8631bf5a94e52d9cc881c0b824ab42717165a5579c760b830d9392ac9",
-                "sha256:a8a4d3427e8de1312ddf309cc482186466c79895b3a139fed3259fc01dfa9a5b",
-                "sha256:a8aca50daa9493e9e13c0f566201a9006f080e7c50e5e90d0b06f53146a54500",
-                "sha256:aa6d0d932e0f39c02b80744273cd5c388a2d9bc07760a03164f229c8e02662f6",
-                "sha256:ab2899f9fa2f9f741896ebb6fa07c4c883bfa5c7f2ddd8cf2aafa86fa981b2d2",
-                "sha256:af545c2cffdb0967a96b6249e6f5f7b0d92cdfd267f9d5238d5b9ca63e8edb10",
-                "sha256:b18f31b80d5a33661e08c89e202edabf1986e9b49c42b4504371daeaa11b47c1",
-                "sha256:b20df693de16f42b2472a9c485e1c948ee55524786a0a34345511afdd22246f3",
-                "sha256:b38765950832f7d728297689ad78f5f2cf79ff82487131c4d26fe6ceecdc5f8e",
-                "sha256:b6f6cd1560c5fa427e3b6074bb24d2c64e225afbb7165008903bd42e4e33e28a",
-                "sha256:bace460460ed20614fa6bc8cb09966c0b8517b8c58ad8046828c6078d25333b5",
-                "sha256:bca9ef7517fd7874a1a08970ae88f497bf5c984610caa0bf40bd7e8450852b95",
-                "sha256:c180f480207a9b2475f2b8d8bd7204e47aec952d084b2a2be58a782ffcf96074",
-                "sha256:c2b2355dc094e5f7d45a7bb262fe7207aa0460b37a0d87027dcf21b5d890e7d5",
-                "sha256:c564dd5f09ddc9d8f2c2d0a301cd30a79a2cc1b46dd1a73bef8f0038863d016b",
-                "sha256:c632ce9c0b534fbe25b52c974515ed674937c5b99f549a92127c85f771a78772",
-                "sha256:c719f65bebcdf6716f10e9eff80d27567f7892d8988c06de12bbbd39307c6e3a",
-                "sha256:c86969d012e51b8e415a8c6ce96f7857d6a87d6207303ab02d5d11ef0cad2274",
-                "sha256:c974fb66180e58709b6fc402846f13791240d180b74de81d23913abe48e96d94",
-                "sha256:c9883051c6972f58bfc4ebb2116345ee2aa151178e99c3f2b2bbe2af712abd13",
-                "sha256:ca9ac61ac6db4eb6c2a0cd1d0f7e1357647b638ccc92f7e9d8d133e71ed3c6ac",
-                "sha256:cb979826071c0986a5f08333a36104153478ce6018c58cba7f9caddaf63d5d67",
-                "sha256:cd3db5927bf9167d5a6157ddb2f036f6b6b0ad001ac82355d43e97a4bde76d76",
-                "sha256:d147004fede1b12f6013a6dbb2a26a986a671a03c6ea740ddc76500e5f1c399f",
-                "sha256:d3a4834f221061624b8887090637db9ad4f61752001eae37d56c52fddade2dc8",
-                "sha256:d9010032a0b9710f58012a1e9c222528763d860ba2ee1422c03473eab47703e7",
-                "sha256:d97f93fdae594d886c5a866636397e2bcab146fd7a132fd6bb9ce182224452f8",
-                "sha256:df23d57718f24badef8656c49743e11a89fd6f5358fa8a7b96e728fda2abf7d3",
-                "sha256:df6104c009713d3a89621096f3e3e88cc323fd269dbd7c20afe18535094320be",
-                "sha256:e5e5f7debc7a57af53fdf5c5009f9391d9f4c12867049d509bf7bb164a6e295b",
-                "sha256:e7d2f8616f0ff60bd332022279011776c3ac0faa0f1b463f7bb12326fbc97a1c",
-                "sha256:e999f0c88a458c836d5fb521814e92ed2172c649200336a6df514987c1488258",
-                "sha256:eb4639f32fd4a9904ab8fb45bf3383ba71137f3d9d4ba25b3b3f3109977c5b8c",
-                "sha256:ec707059ee75732b1ba130ed5f9580fe10ff75180c812bc267ded039db5128c6",
-                "sha256:ecc26751323224cf8186efcf7fbcbc30f4e1d8c7970659daf25ad995e4032a56",
-                "sha256:ee5e86776273de1795947d17bddd6bb19e0365fd2af4289c0d2c5454b6b1d36b",
-                "sha256:f1162a1492032c82f14271e831c8f4b49f2b6078f4f5fc74de2c912fa225d51d",
-                "sha256:f34ecee82858e41dd217734f0c41a532bd066bcaab636ad830f03a30b2a96f2a",
-                "sha256:f85c6f327bf0b8c29da7d93b1cabb6363fb5e4e160a32fa241ed2dce21b73162",
-                "sha256:f92995dfec9420bb69ae629abf422e516923ba79ba4403bc750d94fb4a6c68c1",
-                "sha256:fb0540c854ac9c0c5ad495908fdfd3e332d553ec731698c0e29b1877ba0d2ec6",
-                "sha256:fceedde51fbd67ee2bcc8c0b33d0126cc8b51ef3bbde2f86662bd6d5a6f10ec5",
-                "sha256:fe6970addfea9e5e081401bcbadf865d2b6da045472f58af08427e108d618540",
-                "sha256:fee86b7c4bd29bdaf0d53d14739b08a106fdda809ca5fe032a15f52fae5fe254"
+                "sha256:03ab4530fdcb3a543a122ba4b65ac9919da9fe9f78a03d328a6e38ff962f7aa5",
+                "sha256:07eabb979d236335fed927e137a928c9adfb7df3b9ec7aa31726f133a62be983",
+                "sha256:092e4ce3619a7c6dee52a6bdabda973d9b34b66781f840ce93c7e0cec30cf521",
+                "sha256:10ee9c1753a8f706345b22496c79fbddb5be0599e0823f3738b1534058e25340",
+                "sha256:1601cc37baf5750ccacae618ec2daf020769581695550e3b654a911f859c563d",
+                "sha256:1ac8531b638959718e18c2207fbfe297819875da46a740b29dfa29beba64355a",
+                "sha256:1b9748363260121d2927704f5d4fc498150669ca3ae93625986ee89c8f80dcd4",
+                "sha256:1c1421eb01d4fd608d88cc8290211d177a58532b55ad94076fb349c5bf467f0a",
+                "sha256:1c1af67559445498b502030c35c59db59966f47041ca9de5b4e707f86bd10b5f",
+                "sha256:1d459b98a932296c6f0e94f87511a0b1b90a8a02c30a50e60a297619cd5a58ee",
+                "sha256:20205f7f5ade7aaec9f4b500549bbc071b046453aed72f9c06dcab87896a83e8",
+                "sha256:23119f8fd4f5d16902ed459b63b100bcd269628075162bddac56cc7b5273b3fb",
+                "sha256:237651caadc3a59badd39319c54642b5299e9cc98a3a194310e55d5bb9f5e397",
+                "sha256:24ba13339fed9251d9b1a1bec8c7ab84c0d1675d79d33501e11f94f8b9a84e05",
+                "sha256:250d14af67f6b6a1a4a811049b1afa69d61d617fca6bf33149b3ab1a6dbcf7b8",
+                "sha256:269b76ac5394092b95bc4a098f4fc6c191c083c3bd12775d1e30e663132f6a09",
+                "sha256:27fd7c91e51729b4f7e1577865fa6d34c9adccbc39aabe9000285b48af9f0ec2",
+                "sha256:2964cbf553df4d7a57348da44d961d871895fc1ee4e8c322b2a95612c7b17fba",
+                "sha256:2a73f487ab8ef5abbb24b7aa9b73e98eaba9e9e031804ff2416f02eca315ccaf",
+                "sha256:2aa92c87868cd13674989f9ee83e5f9f7ea4237589b728048e1f0c8f6caa3271",
+                "sha256:2b7edd08e0a5deb1e8564a2fcd8f4561014a3f05252334671bbf55ddd47db0e5",
+                "sha256:2c840c90759922cb5e6dda94596e079a30fb5a5ba548e7e0dc00574703940847",
+                "sha256:2f73e01dc37122325caf079982621262f96d74823c179038a82fddfc50359264",
+                "sha256:2fbc3ed048b3475b9f0cbcb9978e9d2d3511acd91ead203af26ed9f0056004cf",
+                "sha256:2fe3607e71acc6ebb0ec8e492a247bf7a291226192dc0084236dfc12478916f6",
+                "sha256:30099eda75a53c32efb0920e9c33c195314d2cc1c680fbfd30894932ac5f27df",
+                "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035",
+                "sha256:313701e488100074ce99850404ee36e741abf6330179fec908a1944ecf570126",
+                "sha256:317acd9f8602858dc7d59679812c376c7f0b97bcbbf16e0d6237f54141d8a8a6",
+                "sha256:335c0cc3e3545ce98dcb9cfcb836f40c3411f43fa03dab757597d80c89af8a35",
+                "sha256:34b257ec41345c1e8f2df68fa908a7952f5de932723871eb633ecbbff396c9a4",
+                "sha256:367a9314fdc79dab0fac96e216cb41dd73c85bdca85306ce8999118ba7e0f333",
+                "sha256:38e1e7daaea81df51c952e18483f323d878499a1e2bfe564790e0f9701d6f203",
+                "sha256:3e6fc1a85fa7194a1a7d19f44e8609180f4a8eb5fa4c7ed8b4355f080fad235c",
+                "sha256:4132e72c608fe9fecb8f409113567605915b83e9bdd3ea56538d2f9cd35002f1",
+                "sha256:4691802dda97be727f79d86818acaad7eb8e9252626a1d6b519fedbb92d5e251",
+                "sha256:47ddf841cdecc810749921d25606dee45857d12d2ad5ddb7b5bd7eab12e4b365",
+                "sha256:486f7d16ed54c39c2cbd7ca71fd8ba2b8bb7860df65bd7b6ed640bab96a38a8b",
+                "sha256:4cd96b5ba05d67ed0cf00b5b405c8cd99586d8e3481e8ee0a831057591af7621",
+                "sha256:4d6e0ac9da31c9c04c84e1c0182ad8d6df35965a85cae29cd71d089621b3ae94",
+                "sha256:4dfd6e47d3c44c2279907607f73a4240b88c69eb8b90da7e2441a8045dfd21da",
+                "sha256:4f7215cb3933784f79ed20e5f050e15984f390424339b22375d5a53c933a0491",
+                "sha256:4fe1f1087cbadb280b5e1bb054a4f00d1423c74d6626c5e48400d871d34ecefe",
+                "sha256:52cdac9432d8b4a719f35094a818d95adcae0f0b4fe9b9b921909e0c87de9e7d",
+                "sha256:5663ee9257cfa1add7253a7da3035a02f31b6600ec48261585e1800a81533080",
+                "sha256:57fc6745a4b7d0f5a9eb4f40a69718be6c0bc1b8368cc9fe89e90118719f4f42",
+                "sha256:5a837f49d901f9e368651b676912bff1104ed8c1a83b280bcd7b29adccef5c9c",
+                "sha256:5c0b3e614340c889d575451696374c9d17affd54cd607ca0babed8f8c37b9397",
+                "sha256:5e78b522b7a6e27e0b25d19b247b75039ac4c94f99823e3c9e53ae1603a9f7e9",
+                "sha256:5f2504bc0322437c9a1ff6d3333ca56c7477b727c995f036b976ae17b98372c8",
+                "sha256:603a2c834142172ffddc054067f5ec0ca65d57a0aa98a71bc81952573208e345",
+                "sha256:62a759436b29e677181a9e76bab8b8f689a29cb9c535f45f7c48c9c830d3f8c3",
+                "sha256:634e385930fb6d2d479cf3aa66515955863b77a5e3c2b5894ca259a25b308602",
+                "sha256:64c567bf9eaf664280116a8688f63016e6b32db2505908e2bdaca1b6438142f2",
+                "sha256:672ac254412a24d0d0cf00a9e6c238877e4be5e5fa2d188832c1244f45f31966",
+                "sha256:672b9d65f42eb877f5c3f234a4547e4e1a226ca8c2eed879bb34670a0ce51192",
+                "sha256:686b6c0d3911ec387b444ddf5dc62fb7f7c0a7d5186a7861626496a5ab4aff95",
+                "sha256:6f71173be42d3241d428f760122febb748de0623f44308a6f120d0dd9ec572e3",
+                "sha256:6fd35beba67c4183b09375c5fff9accb47524191a244a99f95fd4472f5402c2b",
+                "sha256:6ffbb2f4ec1ceaff7e07d43922954da26b223d188bf30658e561b98e23089444",
+                "sha256:73f05ea02013e02512c3bf42714f1208c57168c779cc6fe23516e4543089d0a6",
+                "sha256:764457a7be60825fb770a644852ff717bcbb5042f189f2bd16df61a81b3f6573",
+                "sha256:797457503c2d426bee06eef808d07b31ede30b65e054444e7de64cad0061b7af",
+                "sha256:7c106c26852ca1c2047c6b80384f17100b4e439af276f21ef3d4e2f450ae7e15",
+                "sha256:7fb4bdf95b0561a79f259f9d28fbc109728c5ee7f27aff6391f0ca703a329abe",
+                "sha256:819c054312f1af92947e6a55883d1b66feefab11531a7fc45e0fb9b63880b5c2",
+                "sha256:8560b4d712474335d08907db7973f71912d3a9a8f1dee992ec06b5d2fe359496",
+                "sha256:86a6dab78b0e43e2897a3bbe15745aa60dc5423ca437b7b0b164c069bf91b876",
+                "sha256:87a5eea1b2a5e21e1ebdbb33ad4165359189327e63fc4e4894693e7f821ac817",
+                "sha256:896e12dfdbbab9d8f7e16d2b28c6769a60126fa92095d1ebf9473d02593a2448",
+                "sha256:8f6bb621e5863cfe8fe5ff5468002d200ec31f30f1280b259dc505b02595099e",
+                "sha256:90d53f1609c29ccc2193945ef732428382a28f78d0456ae4d3daf0d48b74f0f6",
+                "sha256:915fbb7b41b115192259f8c9ae58f3ddc444d2b5579917270211858e606a4afd",
+                "sha256:93b032b5ec3255473c143627d21a69ac74ae12f7f33974cb587c564d11b1066f",
+                "sha256:94da27378da0610e341c4d30de29a191672683cc82b8f9556e8f7c7212a020fe",
+                "sha256:979ed4717f59b8bb12e3963378fa285d93d367e15bcd66c721311826d3c44a6c",
+                "sha256:97e704dcd26271f5bda3fa07c3ce0fb76d6d3f8659f4baa1a24442cc9ba177ca",
+                "sha256:99abd37084b82f5830c635fddd0b4993b9742a66eb746dacf433c8590e8f9e3c",
+                "sha256:9af6779bfb46abf124068327abcdf9ce95c9ef8287a3e8da76ccf2d0f16c28fa",
+                "sha256:9e8f2d660c350b3d0e259c7a7e3d9b7fc8b41210cbcc3d4a7076ff0a5e5c2fdc",
+                "sha256:a24f677ebe83749039e7bdf862ff0bbb16818ae4193d4ef96505e269375bcce0",
+                "sha256:a9875b46d910cff3ea2f5962f9d266b465459fe634e22556ab9bd6fc1192eea0",
+                "sha256:aa00140699487bd435fde4342d85c94cb256b7cd3a5b9c3396c67f19922afda2",
+                "sha256:ae6be797afdef264e8a84864a85b196ca06045586481b3df8a967322fd2fa844",
+                "sha256:af8b4b81a960eeaf1234971ac3cd0ba5901f3cd42eae42a46b4d089a8b492719",
+                "sha256:b165790117eea512d7f3fb22f1f6dad3d55a7189571993eb015591c1401276d1",
+                "sha256:b238af795833d5731d049d82bc84b768ae6f8f97f0495963b3ed9935c5901cc3",
+                "sha256:b3a03285a7f9c7b016324574a6d92a1c895da6b978cb8f1deee3ac72bc6da178",
+                "sha256:b6feea921016eb3d4e04d65fc4e9ca402d1a3801f562aef94989f54694917af3",
+                "sha256:b6ff7fcee63287ae57b5df3e4f5957ce032122802509246dec1a5bcc55904c95",
+                "sha256:b821a1f7dedf7e37450654e620038ac3b2e81e8fa6ea269337e97101978ec730",
+                "sha256:bb2c0c80d431c0d03f2c7dbf125150fedd4f0de17366a7ca33f7ccb822391842",
+                "sha256:bb33777ea21e8b7ecde0e6fc84f598be0a1192eab1a63bc746d75aa75d38e7bd",
+                "sha256:bcfb80a2cc36fba2534e5e5b5264dc7ae6fcd9bf15256da3e53d2f499e6fa29d",
+                "sha256:bd869c427324e5cb15195793de951295710db28be7d818247f3097b4ab5d4b96",
+                "sha256:bedb0cd073cc2dc035e30aeb99444389d3cd2113afe4ef9fcd23d439f5bade85",
+                "sha256:c389c482a7e9b9dc3ee2701ac46c4125297a3818875b9c305ddb603c04828fd1",
+                "sha256:c6fa4dc7ad6f8109c70bb1499e589f76b0b792baf39f9b017eb92c8a81d0a199",
+                "sha256:c83afe0ba876be7e943d2e0ba645809ad441575d2840c895c21ee5de93b9377a",
+                "sha256:cb21957bb8aca671c1765e32f58164cf0c50e6bf41c0bbbd16da20732ecaf588",
+                "sha256:cf4491381b1b57425c315a56a439251b1bdac07b2275f19a8c44bc57744532ec",
+                "sha256:d03f281ed22579314ba00821ce20115a7c0ac430660b4cc05704a3f818b3e004",
+                "sha256:d35143e27778b4bb0fb189562d7f275bff79c62ab8e98459717c0ea617ff2480",
+                "sha256:d3b1a184a9a8f548a6b73f1e26b96b052193e4b3175ed7342aaf1151a1f00a04",
+                "sha256:d44ec478e713ee7f29b439f7eb8dc2b9d4079e11ae114d2c2ac3d5daf30516c8",
+                "sha256:d9d4e294455b23a68c9b8f042d0e8e377a265bcb15332753695f6e5b6819e0ce",
+                "sha256:de538791a80e5d862addbc183f70f0158ac9b9bb872bb147f1fd2a683691e087",
+                "sha256:e4e5e0ae56914ecdbf446493addefc0159053dd53962cef37d7839f37f73d505",
+                "sha256:e509a55f681e6158c20f70f102f9cf61fb20fbc382272bc6d94b7343f2582780",
+                "sha256:ec8dc383ee57ea3e883477dcca3f11b65d58199f1080acaf4cd6ad9a99698be4",
+                "sha256:ed09c7eb1c391271c2ed0314a51903e72a3acb653d5ccfc264cdf3ef11f8269d",
+                "sha256:eeea07c4397bbc57719c4eed8f9c284874d4f175f9b6d57f7a1546b976d455ca",
+                "sha256:eefd9cc9b6d4a2db5f00a26bc3e4f9acf71926a6ec557cd56c9c6f27c290b665",
+                "sha256:f234b4deb12f3ad59127e037bc57c40c21e45b45282df7d3a55a0f409f595296",
+                "sha256:f380468b09d2a81633ee863b0ec5648d364bd17bb8ecfb8c2f387f7ac1faf42c",
+                "sha256:f5e6ff2bdbb8f4cd3fbe41f99e25bbcd58e3bf9f13d3dd31a11e7917251cc77a",
+                "sha256:f7a16ef45b081454ef844502d87a848876c490c4cb5c650c230f6ec79ed2c1e7",
+                "sha256:faccab372e66bc76d5731525e7f1143c922271725b9d38c9f97edcc66266b451",
+                "sha256:fc0cacab7ba4e56f0f81c82a98c09bed2f39c940107b03a34b168bdf7597edd3"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==3.13.5"
+            "markers": "python_version >= '3.10'",
+            "version": "==3.14.1"
         },
         "aiosignal": {
             "hashes": [
@@ -192,12 +191,12 @@
         },
         "ansible": {
             "hashes": [
-                "sha256:1e9b616ff1f3bb5fbf48c89755a1ed395e453dc73d971ed68158933f8bfd4084",
-                "sha256:22dea1938d433fa515b3001cfad65cb308ef97c980f1520174d054dd38f32c83"
+                "sha256:5141552c1bd37f56839eb5b11ef0d93e92391295c97947d507b8daf7265b12b8",
+                "sha256:d011ee5f895ca68b4670e39b910cee447b416a00a3e8d1bd599f4a6dff32ff12"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.11'",
-            "version": "==12.1.0"
+            "markers": "python_version >= '3.12'",
+            "version": "==13.6.0"
         },
         "ansible-compat": {
             "hashes": [
@@ -209,11 +208,11 @@
         },
         "ansible-core": {
             "hashes": [
-                "sha256:afe0438d3acb402319baeb12a52465e69642e7497889a3a979cf390c6061a138",
-                "sha256:ed6399e42384f55886ba1c9947496beb81f6e6b9f15cd90b3013a78baf6649ab"
+                "sha256:28f8cb1647f3459ccd38d098a06a33eaf49cbfce649e506ae6d5f1c2ac77dc1d",
+                "sha256:3066c430e8cba46777bf736ebcd085c90b0d7664c3fbd8c5b85227f8579cdcbf"
             ],
-            "markers": "python_version >= '3.11'",
-            "version": "==2.19.10"
+            "markers": "python_version >= '3.12'",
+            "version": "==2.20.6"
         },
         "ansible-pygments": {
             "hashes": [
@@ -225,12 +224,12 @@
         },
         "antsibull-changelog": {
             "hashes": [
-                "sha256:0cb4528c01afc52539f1422eecd4c9cebb1953d051f53fb66315bdd964ce07d7",
-                "sha256:a0126ffd8f314a469753a755555955373c2e93e215feb817fe7953556279556b"
+                "sha256:0ee9da1be5f2c6da952c21ba2b785ca0da350e9e575a2fffbf6f35a604b81354",
+                "sha256:62100cf13d8719cd03b7bc21968f749adb997de522b073d96e41042ce3a45a1a"
             ],
             "index": "pypi",
             "markers": "python_full_version >= '3.9.0'",
-            "version": "==0.34.0"
+            "version": "==0.35.0"
         },
         "antsibull-core": {
             "hashes": [
@@ -242,12 +241,12 @@
         },
         "antsibull-docs": {
             "hashes": [
-                "sha256:2051ba036b5d52561149a729e3070637e26acf050d6b101370734caa10103a9b",
-                "sha256:af83fa25f4e0fcecb24bc6ad7859a25f612742797546336d121e634295d2b7f2"
+                "sha256:14a9b3633fb2cf962436ea8eda254bfc5cff80ce34b9d51ba0dd46c59b6afb3d",
+                "sha256:d011836a8644996ed5fcaf7bd03b8c5917d5caa68c4b9882fe70d50719121506"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==2.22.0"
+            "version": "==2.24.0"
         },
         "antsibull-docs-parser": {
             "hashes": [
@@ -307,32 +306,37 @@
         },
         "black": {
             "hashes": [
-                "sha256:0172a012f725b792c358d57fe7b6b6e8e67375dd157f64fa7a3097b3ed3e2175",
-                "sha256:0474bca9a0dd1b51791fcc507a4e02078a1c63f6d4e4ae5544b9848c7adfb619",
-                "sha256:154b06d618233fe468236ba1f0e40823d4eb08b26f5e9261526fde34916b9140",
-                "sha256:1b9dc70c21ef8b43248f1d86aedd2aaf75ae110b958a7909ad8463c4aa0880b0",
-                "sha256:2ab0ce111ef026790e9b13bd216fa7bc48edd934ffc4cbf78808b235793cbc92",
-                "sha256:3bec74ee60f8dfef564b573a96b8930f7b6a538e846123d5ad77ba14a8d7a64f",
-                "sha256:456386fe87bad41b806d53c062e2974615825c7a52159cde7ccaeb0695fa28fa",
-                "sha256:474b34c1342cdc157d307b56c4c65bce916480c4a8f6551fdc6bf9b486a7c4ae",
-                "sha256:77e7060a00c5ec4b3367c55f39cf9b06e68965a4f2e61cecacd6d0d9b7ec945a",
-                "sha256:846d58e3ce7879ec1ffe816bb9df6d006cd9590515ed5d17db14e17666b2b357",
-                "sha256:8e46eecf65a095fa62e53245ae2795c90bdecabd53b50c448d0a8bcd0d2e74c4",
-                "sha256:9101ee58ddc2442199a25cb648d46ba22cd580b00ca4b44234a324e3ec7a0f7e",
-                "sha256:a16b14a44c1af60a210d8da28e108e13e75a284bf21a9afa6b4571f96ab8bb9d",
-                "sha256:aaf319612536d502fdd0e88ce52d8f1352b2c0a955cc2798f79eeca9d3af0608",
-                "sha256:b756fc75871cb1bcac5499552d771822fd9db5a2bb8db2a7247936ca48f39831",
-                "sha256:c0372a93e16b3954208417bfe448e09b0de5cc721d521866cd9e0acac3c04a1f",
-                "sha256:ce41ed2614b706fd55fd0b4a6909d06b5bab344ffbfadc6ef34ae50adba3d4f7",
-                "sha256:d119957b37cc641596063cd7db2656c5be3752ac17877017b2ffcdb9dfc4d2b1",
-                "sha256:e3c1f4cd5e93842774d9ee4ef6cd8d17790e65f44f7cdbaab5f2cf8ccf22a823",
-                "sha256:e593466de7b998374ea2585a471ba90553283fb9beefcfa430d84a2651ed5933",
-                "sha256:ef69351df3c84485a8beb6f7b8f9721e2009e20ef80a8d619e2d1788b7816d47",
-                "sha256:f96b6726d690c96c60ba682955199f8c39abc1ae0c3a494a9c62c0184049a713"
+                "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c",
+                "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7",
+                "sha256:28ef38aee69e4b12fda8dba75e21f9b4f979b490c8ac0baa7cb505369ac9e1ff",
+                "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b",
+                "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07",
+                "sha256:2d6bfaf7fd0993b420bed691f20f9492d53ce9a2bcccea4b797d34e947318a78",
+                "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f",
+                "sha256:474c27574d6d7037c1bc875a81d9be0a9a4f9ee95e62800dab3cfaadbf75acd5",
+                "sha256:5602bdb96d52d2d0672f24f6ffe5218795736dd34807fd0fd55ccd6bf206168b",
+                "sha256:5e9d0d86df21f2e1677cc4bd090cd0e446278bcbbe49bf3659c308c3e402843e",
+                "sha256:5ed0ca58586c8d9a487352a96b15272b7fa55d139fc8496b519e78023a8dab0a",
+                "sha256:6c54a4a82e291a1fee5137371ab488866b7c86a3305af4026bdd4dc78642e1ac",
+                "sha256:6e131579c243c98f35bce64a7e08e87fb2d610544754675d4a0e73a070a5aa3a",
+                "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54",
+                "sha256:86a8b5035fce64f5dcd1b794cf8ec4d31fe458cf6ce3986a30deb434df82a1d2",
+                "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f",
+                "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1",
+                "sha256:9a5e9f45e5d5e1c5b5c29b3bd4265dcc90e8b92cf4534520896ed77f791f4da5",
+                "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2",
+                "sha256:b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f",
+                "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1",
+                "sha256:bf9bf162ed91a26f1adba8efda0b573bc6924ec1408a52cc6f82cb73ec2b142c",
+                "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839",
+                "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983",
+                "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb",
+                "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56",
+                "sha256:f89f2ab047c76a9c03f78d0d66ca519e389519902fa27e7a91117ef7611c0568"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
-            "version": "==25.9.0"
+            "markers": "python_version >= '3.10'",
+            "version": "==26.3.1"
         },
         "bracex": {
             "hashes": [
@@ -352,11 +356,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a",
-                "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580"
+                "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897",
+                "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2026.4.22"
+            "version": "==2026.5.20"
         },
         "cffi": {
             "hashes": [
@@ -585,18 +589,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81",
-                "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973"
+                "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2",
+                "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==8.4.0"
-        },
-        "click-help-colors": {
-            "hashes": [
-                "sha256:b33c5803eeaeb084393b1ab5899dc5476c7196b87a18713045afe76f840b42db",
-                "sha256:f4cabe52cf550299b8888f4f2ee4c5f359ac27e33bcfe4d61db47785a5cc936c"
-            ],
-            "version": "==0.9.4"
+            "version": "==8.4.1"
         },
         "coverage": {
             "hashes": [
@@ -679,58 +676,58 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13",
-                "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6",
-                "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8",
-                "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25",
-                "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c",
-                "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832",
-                "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12",
-                "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c",
-                "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7",
-                "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c",
-                "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec",
-                "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5",
-                "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355",
-                "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c",
-                "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741",
-                "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86",
-                "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321",
-                "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a",
-                "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7",
-                "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920",
-                "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e",
-                "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff",
-                "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd",
-                "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3",
-                "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f",
-                "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602",
-                "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855",
-                "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18",
-                "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a",
-                "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336",
-                "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239",
-                "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74",
-                "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a",
-                "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c",
-                "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4",
-                "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c",
-                "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f",
-                "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4",
-                "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db",
-                "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166",
-                "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5",
-                "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f",
-                "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae",
-                "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20",
-                "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a",
-                "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057",
-                "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb",
-                "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c",
-                "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b"
+                "sha256:08a597acce1ff37f347400087776599e2348a3a8bc53b44120e463cd274efe4a",
+                "sha256:09f73a725d582cef64b91281a322cd798d14a33b2b6f2b7ad9531dc336d84c02",
+                "sha256:0df56b056bc17c1b7d6821dfa65216e62bd232d8ab05eb3db44e71d235651471",
+                "sha256:0ee6ea481db1ab889cba043ec1eda17bb9c1ea79db6722f779c3667f9f70322f",
+                "sha256:15254441469dd6bf027039453288e2072124f8b6603563f5d759e1c9b69273fa",
+                "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a",
+                "sha256:2c37f2461406063b417837f5f3daab668652acd82423efcd7f0a9f04be972de1",
+                "sha256:32143b24adb918f078134e1e230f1eb8cc04886b92c28b5f0041aaf3e5699225",
+                "sha256:33842cf0888951cef5bc7ac724ab844a42044c1727b967b7f8997289a0464f92",
+                "sha256:3752f2dbc8f07a30aad2932c986cea495b03bb554887828225da104f732852b6",
+                "sha256:39489bfca54c7a1f6b297efcd8bc608ab92d16c4ca631b0cad4da46724588b24",
+                "sha256:3e4a1a3232eef2e6c732827d5722db29a0cc8b27af2a4d865b094cf954be9ca1",
+                "sha256:3fd2ca57062b241c856670b073487d2e86c4637937ca5601e48f97bf8e11fc8f",
+                "sha256:42fcd8e26fe555d9b3577a135f5091fefa0aa4e99129c23fb56787a1bd4ada72",
+                "sha256:43c5835e2cb98c8733d86f57d6fc879b613f5c3478607281c3e36daffc6dd8a6",
+                "sha256:48fe40804d4caa2288f24e70ca8c64c42dd826da0ad7e4f1b41b2128d679e6c8",
+                "sha256:4ab0a343c807bbcd90c971cd1ecf072937cd01847a9e002bef88fb47ac6be577",
+                "sha256:4fdc69f8e4316bcf0c8c8ec1f26f285d12e8142d88d96c876a59a03be3f6ae67",
+                "sha256:6184ca7b174f28d7c703f1290d4b297217c45355f77a98f67e9b7f14549ac54a",
+                "sha256:66fd0771e7b9c6dcd44cf1120690d2338d16d72795cf40cae2786a39eba65429",
+                "sha256:6b2c0c3e6ccf3ade7750f836ef3ee36eea250cc467d45c256895573ac08cc6f1",
+                "sha256:735824ec41b7f74a7c45fb1591349333e4c696cb6c044e5f46356e560143e4cd",
+                "sha256:7e234ac052af99f2700826a5c29ea99d9c1b1f80341cde62d11c8154dc8e0bd9",
+                "sha256:869c3b8a53bfe27147832df48b32adadf558249d50e76cb3769d40e986b13265",
+                "sha256:86be3b1b0b6bf09482fb50a979c508d2950ed95f5621ec77f4e385962006b83a",
+                "sha256:86fe77abb1bd87afb251d4d02ada7ecf53a32cee9b67d976abb2e45a13297475",
+                "sha256:88c852a0ae366e262e5a1744b685e6a433dc8788dd2a277e418bf4904203609d",
+                "sha256:8ace4507d1e6533c125f4fac754f8bb8b6a74c08e92179dabd7e16571a3efbf3",
+                "sha256:92a46e1d638daa264ba2971c0b0489c9409787943efae4d60ffda3d091ef832c",
+                "sha256:9621de99d2da096006b629979efd8ae7eb2d8b822488d0c89ee4000c306c59b1",
+                "sha256:9a49ca6c81417f6a5edb50375a60cccdd70fa0a91a5211829dbea74eba94d2ac",
+                "sha256:9bd3f92d76217892b15df84ca256c2c113d386fdda7a7d8691aeeced976507c6",
+                "sha256:9de21387aa95e2a895823d0745b430bed4f33503ba9ab5e0b5311f33e37d66d2",
+                "sha256:b024e784ad6c077ee0147b35ea9cbfc1e34e1fd4c1dcca214c2794d73a12df08",
+                "sha256:b4e391975f038e66432328639620a4aff2d307513b004f1ca06d6225bced815c",
+                "sha256:b74ca3b8e5ecdd833bf6a002ca41b4793bb27fb8f1c06ffaf2643c9e9140e31b",
+                "sha256:b7a2d1a937a738a881737cec135a38bb61470589b17515b9f73f571d0ae10401",
+                "sha256:b9a32b876490d66c8bcc9963ef220199569748434ab01a9d6aaeabf88e7f5158",
+                "sha256:bd81490cd5801d755cf97bb68ac191f14b708470b1c7cf4580f669b9c9264cd8",
+                "sha256:c1400da5e32a43253392277eac7490a60e497d810a63dd5608d71bbd7af507c9",
+                "sha256:d069066deead00ac7f090be101be875a06855908f7ec004c27b8fefb4acfb411",
+                "sha256:d5d30989c6917b478b5817902e85fddaea2261efa8648383d965381ccb9e1ac4",
+                "sha256:df637c05205ea7c1d7fbcbe54bbfea648a52951155f997af13d895d0ecc96991",
+                "sha256:e361afba8918070d376df76f408a4f67fec0ee9cff81a99e48fe9a233ef59e17",
+                "sha256:eb86ce1af36fe65041b6db9a8bb064ee621a7e5fded0f80d475ec243477cd242",
+                "sha256:f0d27a5696721ef7a672b8c810f6aded391058e0b9486e63e6d93baf765da691",
+                "sha256:f2ceef93cb096aa3c4cc4b5c94ca6131f9196d28c64d6111533402a9b2054d41",
+                "sha256:f817adc181390bd54f2f700107a7419040fb7c1bdf2fc26f36551a06a68c3345",
+                "sha256:fe0180af5bf9236518a087e35bf2d9a347d5f5f51e63c579d683ddff424e3d46"
             ],
             "markers": "python_version >= '3.9' and python_full_version not in '3.9.0, 3.9.1'",
-            "version": "==48.0.0"
+            "version": "==48.0.1"
         },
         "dill": {
             "hashes": [
@@ -902,11 +899,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8",
-                "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"
+                "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2",
+                "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.15"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.18"
         },
         "imagesize": {
             "hashes": [
@@ -926,11 +923,11 @@
         },
         "isort": {
             "hashes": [
-                "sha256:1bcabac8bc3c36c7fb7b98a76c8abb18e0f841a3ba81decac7691008592499c1",
-                "sha256:5513527951aadb3ac4292a41a16cbc50dd1642432f5e8c20057d414bdafb4187"
+                "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d",
+                "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75"
             ],
             "markers": "python_full_version >= '3.10.0'",
-            "version": "==7.0.0"
+            "version": "==8.0.1"
         },
         "jinja2": {
             "hashes": [
@@ -1077,12 +1074,12 @@
         },
         "molecule": {
             "hashes": [
-                "sha256:0efe39245ccefbb440ef39f1af50eb647bf82fef57892078fa880f6e14c0b505",
-                "sha256:1a56d283b1fb5488439eac945971dbd66b772ed43b2c66a776922cb93d39fbfd"
+                "sha256:12e4c905079f67628ae765506c697d2b8a744a65f2d4cbf5a3b22cb09d0dafc4",
+                "sha256:b231f4955f95240a8e2b8194c086d0b5e8ab998032a9411eafe85429442a3bd5"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==25.9.0"
+            "version": "==26.4.0"
         },
         "molecule-plugins": {
             "extras": [
@@ -1281,11 +1278,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a",
-                "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"
+                "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7",
+                "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==4.9.6"
+            "version": "==4.10.0"
         },
         "pluggy": {
             "hashes": [
@@ -1582,12 +1579,12 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:9627ccd129893fb8ee8e8010261cb13485daca83e61a6f854a85528ee579502d",
-                "sha256:9c22dfa52781d3b79ce86ab2463940f874921a3e5707bcfc98dd0c019945014e"
+                "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2",
+                "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c"
             ],
             "index": "pypi",
             "markers": "python_full_version >= '3.10.0'",
-            "version": "==4.0.2"
+            "version": "==4.0.5"
         },
         "pyproject-hooks": {
             "hashes": [
@@ -1599,12 +1596,12 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01",
-                "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"
+                "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9",
+                "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
-            "version": "==8.4.2"
+            "markers": "python_version >= '3.10'",
+            "version": "==9.0.3"
         },
         "pytest-forked": {
             "hashes": [
@@ -1802,124 +1799,139 @@
         },
         "rpds-py": {
             "hashes": [
-                "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f",
-                "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136",
-                "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3",
-                "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7",
-                "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65",
-                "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4",
-                "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169",
-                "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf",
-                "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4",
-                "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2",
-                "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c",
-                "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4",
-                "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3",
-                "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6",
-                "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7",
-                "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89",
-                "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85",
-                "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6",
-                "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa",
-                "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb",
-                "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6",
-                "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87",
-                "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856",
-                "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4",
-                "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f",
-                "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53",
-                "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229",
-                "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad",
-                "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23",
-                "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db",
-                "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038",
-                "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27",
-                "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00",
-                "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18",
-                "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083",
-                "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c",
-                "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738",
-                "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898",
-                "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e",
-                "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7",
-                "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08",
-                "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6",
-                "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551",
-                "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e",
-                "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288",
-                "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df",
-                "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0",
-                "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2",
-                "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05",
-                "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0",
-                "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464",
-                "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5",
-                "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404",
-                "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7",
-                "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139",
-                "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394",
-                "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb",
-                "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15",
-                "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff",
-                "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed",
-                "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6",
-                "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e",
-                "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95",
-                "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d",
-                "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950",
-                "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3",
-                "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5",
-                "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97",
-                "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e",
-                "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e",
-                "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b",
-                "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd",
-                "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad",
-                "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8",
-                "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425",
-                "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221",
-                "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d",
-                "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825",
-                "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51",
-                "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e",
-                "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f",
-                "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8",
-                "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f",
-                "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d",
-                "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07",
-                "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877",
-                "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31",
-                "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58",
-                "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94",
-                "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28",
-                "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000",
-                "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1",
-                "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1",
-                "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7",
-                "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7",
-                "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40",
-                "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d",
-                "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0",
-                "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84",
-                "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f",
-                "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a",
-                "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7",
-                "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419",
-                "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8",
-                "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a",
-                "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9",
-                "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be",
-                "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed",
-                "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a",
-                "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d",
-                "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324",
-                "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f",
-                "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2",
-                "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f",
-                "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5"
+                "sha256:01d17b29c0c23d82b1f4751147ec49cf451f1fc2554eb9ef5f957e55d2656ead",
+                "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a",
+                "sha256:0408a24e44feb919423dc6d9da677cb5cddb894d2ca9e763967d156d9c60fab4",
+                "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256",
+                "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb",
+                "sha256:0a5ae4dbe43c1076983b72616496919872ae7bbe7a1e21cc48336bc3154d130b",
+                "sha256:0a7d1eec967df0e9b22614a5e177622e0c89611d03727fa0cb48e45028907870",
+                "sha256:0b35217adefe87f2fe4db7e9766cabe84744bfe9616d9667be18988928c7f2dc",
+                "sha256:0fa92420128dadce7f54bd73ba1825a273e9268fe9e35dbf7e6362890efa4e08",
+                "sha256:141c9498daf2ace9eda35d2b0e376f9ea8b058d84f2aef4f96fccfd449a2f251",
+                "sha256:1841d067089e117142d79b98aa0df2f08b52f2ecc1819dd2700636c0db74a473",
+                "sha256:19cb09fab7b7fc96b2a6e28f2e34b72a3705ff27b37edb77455316e5d3f3dc9b",
+                "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a",
+                "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131",
+                "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9",
+                "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01",
+                "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba",
+                "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad",
+                "sha256:277f6c82f0580848796c7ecc8a7173aa3bfb928e4ff831261c2f60a81dc270db",
+                "sha256:27b74c10ed6a8f190f4287f53bcfea348b92a84a9c9f70d30183d1e6172d580d",
+                "sha256:296c799becfa849c779c8725494fe9ed94959ed886787df4364b058465bad7f0",
+                "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63",
+                "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee",
+                "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7",
+                "sha256:3350ec808fb538fe71a1f94dfaa0e29c598dfad805ce49f0caec5ae3183c652b",
+                "sha256:3397a5ed7174dc2786bb214030232fc36fe8e5584fec43a9952cc542b1a12036",
+                "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb",
+                "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16",
+                "sha256:3684a59b158a7683aaeb8e25352e9a9dd2122cec78f2d8530266e4f91b4c7b3f",
+                "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d",
+                "sha256:3abe24a66e57adcfa645d718063a5fa5103ecc71ddbf26d78af8f9368018ff1d",
+                "sha256:40ff257542e04796880e011e15cd4dc21c2599975df2aaa8f2c8495ca574e1a5",
+                "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78",
+                "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66",
+                "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972",
+                "sha256:453895624ecf7db7063b1004e44037522bbaef9ff6a945e59bc71662d7a03abd",
+                "sha256:4860b603ddda0475a8885499b3729e90229d480105b42651962a5397d995fa89",
+                "sha256:4be8b1d2a705cc37d08256004e1d07de143fa0075c8e85a3df020b776f62b732",
+                "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02",
+                "sha256:4fb8d2e7cb2f850b169806d61d1b991738acec96500a75c30f49caf064ce7cef",
+                "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a",
+                "sha256:58b1d94308ddf0b1982f61f2eb54bf92997c9ece8a8093ef014250f4a517906c",
+                "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723",
+                "sha256:613fc4ee9eaef26dc5840666214dd6fbcebcf32f46e76f4abc473059f4e13dda",
+                "sha256:6142dbd80c4df62a5d899f0d616d417f84e0bc8d32526c8e5589019d75d028a7",
+                "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca",
+                "sha256:63c2c4c213f1a4e3f3de28ecab029dbdee976324e729c0d7a55211be72576b02",
+                "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015",
+                "sha256:66c93681c4729e4e3ecba31b8179fae083ff3118841672835140338b4b9867c1",
+                "sha256:6736718bd4fc49cbcb538ba30516fdbef161522acefb739657d48b97bd864fed",
+                "sha256:68700371c5d7ae1412862ddfa719090925c93ecf351c566d66f09d04b136ea00",
+                "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a",
+                "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195",
+                "sha256:6f249f8b860a200ad35193af961183ebe9132710484e6f6ce0cf89fd83c63a9a",
+                "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa",
+                "sha256:7559f72b94ae52659086c595dfa017cde03155f7832071d30959049052cb3ece",
+                "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df",
+                "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26",
+                "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa",
+                "sha256:7944270ae71383f6e2657dd7d5ce4eeb4ac2d0059a6738f0510583d462ab4842",
+                "sha256:7bd530e6a530bb3ea892f194fafa455f3516ac25ecf7143fd33c09be62b0470a",
+                "sha256:8213afbe8a3a906fb9acb2014423fe3359ee783d0bf90995f70623a3217bfa6c",
+                "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd",
+                "sha256:85264a90ff4c05c1568dd65f5921c837614b67c60358fb4c17df3b7f2e90690a",
+                "sha256:88647f43a73c4e01be19b04ceef0c8d3a1958153604d13c773becd8016f2a0cf",
+                "sha256:8895840ac4809e5f60c88fd07617cd71326e73d6e5a8aa783c5c0f7c24985de2",
+                "sha256:8ba264fa49be666cd9cc56bf34ec7002fb3d27a4aee5bcb4d43d0d18feb1bb6f",
+                "sha256:8bff7073db3899158fff55ebf57b113a67030af26f80a18978f9f0aa60250ddf",
+                "sha256:8c43a8a973270fd173bf48cdf80bbe66312421cba68d40845034f174f2389049",
+                "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3",
+                "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964",
+                "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291",
+                "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14",
+                "sha256:99ab6ba7bfa2cb0f96a04e3652355bf04e3f51aceb1e943b8541dab7ba4828cc",
+                "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47",
+                "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5",
+                "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d",
+                "sha256:9e25b7088f9ccbfc0dfcaa52bf969300ca229e10ecf758974ebcbb080a4b37bb",
+                "sha256:a04df86b3f0fade39ec8fd0e0aab089b1da9fbd2b48df778a57ef96f5e7d38df",
+                "sha256:a05fa4f41f37ec97c9c260441a940450a192f78d774d2b097eee1379f1e1246a",
+                "sha256:a2999883eedf72fdfb7520b92c7d4ec2572a71ff40239377aa604cc529eecafc",
+                "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc",
+                "sha256:abe76bcdba31e576cb83eeb8797aa0d882b738fef6dc65d0601fc753806a5b46",
+                "sha256:ad3773236e95f7f33991eb125224b7da66f206504d032a253a02da7e134519fb",
+                "sha256:af03e34e860047bc7a352b842856fcf78798fbb81132cc98bd2f907ab4eb9cd2",
+                "sha256:b1b964e3ab599e718dc46c018d104b1ebc007cbc6567d827c94a687fca56d77e",
+                "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb",
+                "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec",
+                "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325",
+                "sha256:b4e4bc98639ec915f512fde3aa7a95e0041d95d9c3cc86eea841fa63cb1e8600",
+                "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559",
+                "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41",
+                "sha256:b6825cc329b290e93c5f6a9be2393118a763f6ccf6abd83704e0c102ca583644",
+                "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b",
+                "sha256:b95d5e11fc712b752081183a55a244c03cd00570489edd7014d8899f8ceb8162",
+                "sha256:b9a6528956191c48c52294a592dbd4a8386d7048bdb25c0efcb6b966466c6d83",
+                "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038",
+                "sha256:c0f920015df2a504bebaba6d4c31ccf3fcf942f92655c086da30b671aad19aa6",
+                "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b",
+                "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3",
+                "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9",
+                "sha256:c74005a7bb87752acf351c93897ec63ad77a07a0da7ecad9c050e32e7286ba34",
+                "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6",
+                "sha256:ca653c6546386227cd9800d1bef6a348099acf8db4250341da6d90f663d6dfcb",
+                "sha256:cacedb7a6e167680acba45ad5716e89067d225dc80da0d7040cae8c81d4572fa",
+                "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6",
+                "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d",
+                "sha256:cea68bcd53467561ae2f96a6bdad1544299ba97b5b0ddcd5ac3d376e5c781c24",
+                "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838",
+                "sha256:d0efbe45632665e53e3db8fe1e5692db58fc5cb9bab4459d570b83efefe11164",
+                "sha256:d3858b908218ee108d0bbfb2095ccc237648053c9bf98affad7cb079acaf1d97",
+                "sha256:de42116e69cb53b911cc34aee5ab98f36c597b822545045d49e938818b99e5e4",
+                "sha256:df1d2a1996755b24b9ecee92cb4d36c28f86f464a6a173349c26bab41e94b8c2",
+                "sha256:e07be2a9d7122bd6e82dea89814ef8dc893feb1aae97fec1630f3263bbb30e55",
+                "sha256:e0b360f316d966b048b085857630b3cc51f3db2f07b06f440eac8f695374d1e3",
+                "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2",
+                "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358",
+                "sha256:e4abbf391a70be864920858bf360f4fb380577c9a0f732438a1996726e2c195b",
+                "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8",
+                "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0",
+                "sha256:edf2765d84e42447f112ad877af8fe1db0089aaec5b28e88d6eab45e7fe99cea",
+                "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081",
+                "sha256:efef4ac29c6ff495531eb17ee705b62841ecaa291b7c7077e848ea03e237164d",
+                "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1",
+                "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81",
+                "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3",
+                "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8",
+                "sha256:fc0c0f878ea770a0a8a462456c5ad36fc9fe6358e6b76fdadc7f17575e0b8bf1",
+                "sha256:fe71bca7d547acb17027c7fd1624ff8aae623499c498d3e7011182c4de5c25e0",
+                "sha256:fea6e836d10abbe191d557d33bd58bd5987725fe63aa1eefe557d230209855bd"
             ],
-            "markers": "python_version >= '3.10'",
-            "version": "==0.30.0"
+            "markers": "python_version >= '3.11'",
+            "version": "==2026.5.1"
         },
         "rstcheck": {
             "hashes": [
@@ -1963,19 +1975,19 @@
         },
         "snowballstemmer": {
             "hashes": [
-                "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064",
-                "sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895"
+                "sha256:7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752",
+                "sha256:e07bbc54a0d798fe6010a12398422e62a8bfbba95c394fd0956ef58cb4d3e260"
             ],
-            "markers": "python_version not in '3.0, 3.1, 3.2'",
-            "version": "==3.0.1"
+            "markers": "python_version >= '3.3'",
+            "version": "==3.1.1"
         },
         "sphinx": {
             "hashes": [
-                "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3",
-                "sha256:5bebc595a5e943ea248b99c13814c1c5e10b3ece718976824ffa7959ff95fffb"
+                "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb",
+                "sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978"
             ],
-            "markers": "python_version >= '3.11'",
-            "version": "==9.0.4"
+            "markers": "python_version >= '3.12'",
+            "version": "==9.1.0"
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
@@ -2050,11 +2062,11 @@
         },
         "typer": {
             "hashes": [
-                "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89",
-                "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc"
+                "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58",
+                "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==0.25.1"
+            "version": "==0.26.7"
         },
         "typing-extensions": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,23 +1,11 @@
 {
     "_meta": {
         "hash": {
-<<<<<<< Updated upstream
-            "sha256": "b0ffa1f26f2aa5db25abf06c0c2fec3318e9e94ccaf41f11623d25ef97c46167"
+            "sha256": "d37613d650a5cbcead624bfa4a50afa69aecebb49a8da6874e16e7ac890c9933"
         },
         "pipfile-spec": 6,
         "requires": {
             "python_version": "3.13"
-=======
-<<<<<<< Updated upstream
-            "sha256": "043b9f5041bb1d4ae3c23a9b89d994a292efed8693c5c5e92bdbad78a01f8cf3"
-=======
-            "sha256": "3464c6e1c650e793b5caba54a53636ff0825d1a5bc1be96d9fe1690154af6b28"
->>>>>>> Stashed changes
-        },
-        "pipfile-spec": 6,
-        "requires": {
-            "python_version": "3.11"
->>>>>>> Stashed changes
         },
         "sources": [
             {
@@ -1782,7 +1770,6 @@
             "markers": "python_full_version >= '3.9.0'",
             "version": "==15.0.0"
         },
-<<<<<<< Updated upstream
         "roman-numerals": {
             "hashes": [
                 "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2",
@@ -1791,8 +1778,6 @@
             "markers": "python_version >= '3.10'",
             "version": "==4.1.0"
         },
-=======
->>>>>>> Stashed changes
         "rpds-py": {
             "hashes": [
                 "sha256:01d17b29c0c23d82b1f4751147ec49cf451f1fc2554eb9ef5f957e55d2656ead",

--- a/changelogs/fragments/197-drop-python-up-to-3.10-ansible-up-to-2.17.yml
+++ b/changelogs/fragments/197-drop-python-up-to-3.10-ansible-up-to-2.17.yml
@@ -1,0 +1,13 @@
+---
+breaking_changes:
+  - >-
+    The minimum supported control-node Python is now 3.11. Python 3.8, 3.9 and
+    3.10 are no longer supported.
+  - >-
+    The minimum supported ``ansible-core`` is now 2.18. ``ansible-core`` 2.12
+    through 2.17 are no longer tested or supported, as their lowest supported
+    control-node Python is below the new floor.
+minor_changes:
+  - >-
+    CI matrix updated to test against ``ansible-core`` 2.18, 2.19 and ``devel``
+    on Python 3.11, 3.12 and 3.13.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.11.0'  # Use '>=2.9.10' instead, if needed
+requires_ansible: '>=2.18.0'
 plugin_routing:
   modules:
     firewall_alias:

--- a/molecule/_inventory/group_vars/opnsense.yml
+++ b/molecule/_inventory/group_vars/opnsense.yml
@@ -1,0 +1,13 @@
+---
+vagrant_box: puzzle/opnsense
+vagrant_memory: 1024
+vagrant_cpus: 2
+
+ansible_connection: ssh
+ansible_user: vagrant
+ansible_ssh_common_args: "-F {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/.vagrant_ssh_config"
+ansible_shell_type: sh
+ansible_shell_executable: /bin/sh
+ansible_become: true
+ansible_become_method: sudo
+ansible_become_exe: sudo

--- a/molecule/_inventory/host_vars/24.7.yml
+++ b/molecule/_inventory/host_vars/24.7.yml
@@ -1,0 +1,2 @@
+---
+vagrant_box_version: "24.7"

--- a/molecule/_inventory/host_vars/25.1.yml
+++ b/molecule/_inventory/host_vars/25.1.yml
@@ -1,0 +1,2 @@
+---
+vagrant_box_version: "25.1"

--- a/molecule/_inventory/host_vars/25.7.yml
+++ b/molecule/_inventory/host_vars/25.7.yml
@@ -1,0 +1,2 @@
+---
+vagrant_box_version: "25.7"

--- a/molecule/_inventory/host_vars/26.1.yml
+++ b/molecule/_inventory/host_vars/26.1.yml
@@ -1,0 +1,2 @@
+---
+vagrant_box_version: "26.1"

--- a/molecule/_inventory/hosts.ini
+++ b/molecule/_inventory/hosts.ini
@@ -1,0 +1,43 @@
+[firewall_alias]
+24.7 vagrant_box_version=24.7
+
+[firewall_rules]
+24.7
+
+[interfaces_assignments]
+24.7
+25.1 vagrant_box_version=25.1
+25.7 vagrant_box_version=25.7
+26.1 vagrant_box_version=26.1
+
+[opnsense_config]
+24.7
+25.1
+25.7
+26.1
+
+[system_access_users]
+24.7
+
+[system_high_availability_settings]
+24.7
+25.1
+
+[system_settings_general]
+24.7
+25.1
+25.7
+26.1
+
+[system_settings_logging]
+24.7
+
+[opnsense:children]
+firewall_alias
+firewall_rules
+interfaces_assignments
+opnsense_config
+system_access_users
+system_high_availability_settings
+system_settings_general
+system_settings_logging

--- a/molecule/_inventory/hosts.ini
+++ b/molecule/_inventory/hosts.ini
@@ -1,14 +1,14 @@
 [firewall_alias]
-24.7 vagrant_box_version=24.7
+24.7
 
 [firewall_rules]
 24.7
 
 [interfaces_assignments]
 24.7
-25.1 vagrant_box_version=25.1
-25.7 vagrant_box_version=25.7
-26.1 vagrant_box_version=26.1
+25.1
+25.7
+26.1
 
 [opnsense_config]
 24.7

--- a/molecule/_resources/create.yml
+++ b/molecule/_resources/create.yml
@@ -1,0 +1,36 @@
+---
+- name: Create OPNsense VMs for scenario
+  hosts: localhost
+  gather_facts: false
+  vars:
+    ephemeral_dir: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
+    scenario_name: "{{ lookup('env', 'MOLECULE_SCENARIO_NAME') }}"
+    scenario_hosts: "{{ groups[scenario_name] }}"
+  tasks:
+    - name: Validate scenario group exists in inventory
+      ansible.builtin.assert:
+        that:
+          - scenario_hosts | length > 0
+        fail_msg: "No hosts found in inventory group '{{ scenario_name }}'"
+
+    - name: Template Vagrantfile
+      ansible.builtin.template:
+        src: templates/Vagrantfile.j2
+        dest: "{{ ephemeral_dir }}/Vagrantfile"
+        mode: "0644"
+
+    - name: Run vagrant up
+      ansible.builtin.command:
+        cmd: vagrant up --provider=virtualbox
+        chdir: "{{ ephemeral_dir }}"
+      register: vagrant_up
+      changed_when: true
+
+    - name: Write SSH config
+      ansible.builtin.shell:
+        cmd: vagrant ssh-config > .vagrant_ssh_config
+        chdir: "{{ ephemeral_dir }}"
+      changed_when: true
+
+- name: Preconfigure OPNsense VMs
+  ansible.builtin.import_playbook: preconfig.yml

--- a/molecule/_resources/destroy.yml
+++ b/molecule/_resources/destroy.yml
@@ -1,0 +1,29 @@
+---
+- name: Destroy OPNsense VMs for scenario
+  hosts: localhost
+  gather_facts: false
+  vars:
+    ephemeral_dir: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
+  tasks:
+    - name: Check if Vagrantfile exists
+      ansible.builtin.stat:
+        path: "{{ ephemeral_dir }}/Vagrantfile"
+      register: vagrantfile_stat
+
+    - name: Run vagrant destroy
+      ansible.builtin.command:
+        cmd: vagrant destroy --force
+        chdir: "{{ ephemeral_dir }}"
+      when: vagrantfile_stat.stat.exists
+      changed_when: true
+      failed_when: false
+
+    - name: Remove SSH config
+      ansible.builtin.file:
+        path: "{{ ephemeral_dir }}/.vagrant_ssh_config"
+        state: absent
+
+    - name: Remove Vagrantfile
+      ansible.builtin.file:
+        path: "{{ ephemeral_dir }}/Vagrantfile"
+        state: absent

--- a/molecule/_resources/destroy.yml
+++ b/molecule/_resources/destroy.yml
@@ -16,7 +16,6 @@
         chdir: "{{ ephemeral_dir }}"
       when: vagrantfile_stat.stat.exists
       changed_when: true
-      failed_when: false
 
     - name: Remove SSH config
       ansible.builtin.file:

--- a/molecule/_resources/preconfig.yml
+++ b/molecule/_resources/preconfig.yml
@@ -1,0 +1,11 @@
+---
+- name: Preconfigure OPNsense VMs
+  hosts: "{{ lookup('env', 'MOLECULE_SCENARIO_NAME') }}"
+  gather_facts: false
+  tasks:
+    - name: Wait for SSH connectivity
+      ansible.builtin.wait_for_connection:
+        timeout: 300
+
+    - name: Validate connectivity
+      ansible.builtin.ping:

--- a/molecule/_resources/templates/Vagrantfile.j2
+++ b/molecule/_resources/templates/Vagrantfile.j2
@@ -1,0 +1,22 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+{% for host in scenario_hosts %}
+  config.vm.define "{{ host }}" do |node|
+    node.vm.box = "{{ hostvars[host]['vagrant_box'] }}"
+    node.vm.box_version = "{{ hostvars[host]['vagrant_box_version'] }}"
+    node.vm.guest = :freebsd
+    node.ssh.shell = "/bin/sh"
+    node.ssh.sudo_command = "%c"
+
+    node.vm.provider "virtualbox" do |vb|
+      vb.memory = {{ hostvars[host]['vagrant_memory'] | default(1024) }}
+      vb.cpus = {{ hostvars[host]['vagrant_cpus'] | default(2) }}
+    end
+  end
+
+{% endfor %}
+end

--- a/molecule/firewall_alias/converge.yml
+++ b/molecule/firewall_alias/converge.yml
@@ -1,6 +1,6 @@
 ---
 - name: converge
-  hosts: all
+  hosts: firewall_alias
   become: true
   tasks:
 

--- a/molecule/firewall_alias/molecule.yml
+++ b/molecule/firewall_alias/molecule.yml
@@ -1,37 +1,26 @@
 ---
 scenario:
-    name: firewall_alias
-    test_sequence:
-        # - dependency not relevant unless we have requirements
-        - destroy
-        - syntax
-        - create
-        - converge
-        - idempotence
-        - verify
-        - destroy
+  name: firewall_alias
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - verify
+    - destroy
 
-driver:
-    name: vagrant
-    parallel: true
+ansible:
+  playbooks:
+    create: ../_resources/create.yml
+    destroy: ../_resources/destroy.yml
+  executor:
+    backend: ansible-playbook
+    args:
+      ansible_playbook:
+        - --inventory=${MOLECULE_PROJECT_DIRECTORY}/molecule/_inventory/
 
-platforms:
-    - name: "24.7"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "24.7"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-          - 'vm.guest = :freebsd'
-          - 'ssh.sudo_command = "%c"'
-          - 'ssh.shell = "/bin/sh"'
-
-provisioner:
-    name: ansible
-    env:
-        ANSIBLE_LIBRARY: "${VIRTUAL_ENV}/lib/python3.11/site-packages/molecule_plugins/vagrant/modules"
 verifier:
-    name: ansible
-    options:
-        become: true
+  name: ansible
+  options:
+    become: true

--- a/molecule/firewall_alias/verify.yml
+++ b/molecule/firewall_alias/verify.yml
@@ -1,6 +1,6 @@
 ---
 - name: Verify connectivity to server
-  hosts: all
+  hosts: firewall_alias
   tasks:
     - name: Ping the server
       ansible.builtin.ping:

--- a/molecule/firewall_rules/converge.yml
+++ b/molecule/firewall_rules/converge.yml
@@ -1,6 +1,6 @@
 ---
 - name: converge
-  hosts: all
+  hosts: firewall_rules
   become: true
   tasks:
     # this rule should have the extra attributes 'create' updated'

--- a/molecule/firewall_rules/molecule.yml
+++ b/molecule/firewall_rules/molecule.yml
@@ -2,7 +2,6 @@
 scenario:
   name: firewall_rules
   test_sequence:
-    # - dependency not relevant unless we have requirements
     - destroy
     - syntax
     - create
@@ -11,26 +10,16 @@ scenario:
     - cleanup
     - destroy
 
-driver:
-  name: vagrant
-  parallel: true
+ansible:
+  playbooks:
+    create: ../_resources/create.yml
+    destroy: ../_resources/destroy.yml
+  executor:
+    backend: ansible-playbook
+    args:
+      ansible_playbook:
+        - --inventory=${MOLECULE_PROJECT_DIRECTORY}/molecule/_inventory/
 
-platforms:
-  - name: "24.7"
-    box: puzzle/opnsense
-    hostname: false
-    box_version: "24.7"
-    memory: 1024
-    cpus: 2
-    instance_raw_config_args:
-      - 'vm.guest = :freebsd'
-      - 'ssh.sudo_command = "%c"'
-      - 'ssh.shell = "/bin/sh"'
-
-provisioner:
-  name: ansible
-  env:
-    ANSIBLE_LIBRARY: "${VIRTUAL_ENV}/lib/python3.11/site-packages/molecule_plugins/vagrant/modules"
 verifier:
   name: ansible
   options:

--- a/molecule/interfaces_assignments/converge.yml
+++ b/molecule/interfaces_assignments/converge.yml
@@ -1,6 +1,6 @@
 ---
 - name: converge
-  hosts: all
+  hosts: interfaces_assignments
   become: true
   tasks:
     - name: Test interface lan, device em1 description update

--- a/molecule/interfaces_assignments/molecule.yml
+++ b/molecule/interfaces_assignments/molecule.yml
@@ -1,67 +1,26 @@
 ---
 scenario:
-    name: interfaces_assignments
-    test_sequence:
-        # - dependency not relevant uless we have requirements
-        - destroy
-        - syntax
-        - create
-        - converge
-        - idempotence
-        - verify
-        - destroy
+  name: interfaces_assignments
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - verify
+    - destroy
 
-driver:
-    name: vagrant
-    parallel: true
+ansible:
+  playbooks:
+    create: ../_resources/create.yml
+    destroy: ../_resources/destroy.yml
+  executor:
+    backend: ansible-playbook
+    args:
+      ansible_playbook:
+        - --inventory=${MOLECULE_PROJECT_DIRECTORY}/molecule/_inventory/
 
-platforms:
-    - name: "24.7"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "24.7"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-        - 'vm.guest = :freebsd'
-        - 'ssh.sudo_command = "%c"'
-        - 'ssh.shell = "/bin/sh"'
-    - name: "25.1"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "25.1"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-        - 'vm.guest = :freebsd'
-        - 'ssh.sudo_command = "%c"'
-        - 'ssh.shell = "/bin/sh"'
-    - name: "25.7"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "25.7"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-        - 'vm.guest = :freebsd'
-        - 'ssh.sudo_command = "%c"'
-        - 'ssh.shell = "/bin/sh"'
-    - name: "26.1"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "26.1"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-        - 'vm.guest = :freebsd'
-        - 'ssh.sudo_command = "%c"'
-        - 'ssh.shell = "/bin/sh"'
-
-provisioner:
-    name: ansible
-    env:
-        ANSIBLE_LIBRARY: "${VIRTUAL_ENV}/lib/python3.11/site-packages/molecule_plugins/vagrant/modules"
 verifier:
-    name: ansible
-    options:
-        become: true
+  name: ansible
+  options:
+    become: true

--- a/molecule/interfaces_assignments/verify.yml
+++ b/molecule/interfaces_assignments/verify.yml
@@ -1,6 +1,6 @@
 ---
 - name: Verify connectivity to server
-  hosts: all
+  hosts: interfaces_assignments
   tasks:
     - name: Ping the server
       ansible.builtin.ping:

--- a/molecule/opnsense_config/converge.yml
+++ b/molecule/opnsense_config/converge.yml
@@ -1,6 +1,6 @@
 ---
 - name: converge
-  hosts: all
+  hosts: opnsense_config
   become: true
   vars:
 

--- a/molecule/opnsense_config/host_vars/26.1.yml
+++ b/molecule/opnsense_config/host_vars/26.1.yml
@@ -1,0 +1,8 @@
+---
+system:
+  settings:
+    general:
+      hostname: "firewall01"
+      domain: "test.local"
+      timezone: "Europe/Zurich"
+firewall: {}

--- a/molecule/opnsense_config/molecule.yml
+++ b/molecule/opnsense_config/molecule.yml
@@ -1,72 +1,26 @@
 ---
 scenario:
-    name: opnsense_config
-    test_sequence:
-        # - dependency not relevant unless we have requirements
-        - destroy
-        - syntax
-        - create
-        - converge
-        - idempotence
-        - verify
-        - destroy
+  name: opnsense_config
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - verify
+    - destroy
 
-driver:
-    name: vagrant
-    parallel: true
-
-platforms:
-    - name: "24.7"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "24.7"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-          - 'vm.guest = :freebsd'
-          - 'ssh.sudo_command = "%c"'
-          - 'ssh.shell = "/bin/sh"'
-    - name: "25.1"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "25.1"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-          - 'vm.guest = :freebsd'
-          - 'ssh.sudo_command = "%c"'
-          - 'ssh.shell = "/bin/sh"'
-    - name: "25.7"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "25.7"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-          - 'vm.guest = :freebsd'
-          - 'ssh.sudo_command = "%c"'
-          - 'ssh.shell = "/bin/sh"'
-    - name: "26.1"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "26.1"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-          - 'vm.guest = :freebsd'
-          - 'ssh.sudo_command = "%c"'
-          - 'ssh.shell = "/bin/sh"'
-
-provisioner:
-    name: ansible
-    env:
-        ANSIBLE_LIBRARY: "${VIRTUAL_ENV}/lib/python3.11/site-packages/molecule_plugins/vagrant/modules"
-    inventory:
-      links:
-        group_vars: "./group_vars/"
-        host_vars: "./host_vars/"
+ansible:
+  playbooks:
+    create: ../_resources/create.yml
+    destroy: ../_resources/destroy.yml
+  executor:
+    backend: ansible-playbook
+    args:
+      ansible_playbook:
+        - --inventory=${MOLECULE_PROJECT_DIRECTORY}/molecule/_inventory/
 
 verifier:
-    name: ansible
-    options:
-        become: true
+  name: ansible
+  options:
+    become: true

--- a/molecule/opnsense_config/verify.yml
+++ b/molecule/opnsense_config/verify.yml
@@ -1,6 +1,6 @@
 ---
 - name: Verify connectivity to server
-  hosts: all
+  hosts: opnsense_config
   tasks:
     - name: Ping the server
       ansible.builtin.ping:

--- a/molecule/system_access_users/converge.yml
+++ b/molecule/system_access_users/converge.yml
@@ -1,6 +1,6 @@
 ---
 - name: converge
-  hosts: all
+  hosts: system_access_users
   become: true
   tasks:
     - name: "test"

--- a/molecule/system_access_users/molecule.yml
+++ b/molecule/system_access_users/molecule.yml
@@ -1,39 +1,26 @@
 ---
 scenario:
-    name: system_access_users
-    test_sequence:
-        # - dependency not relevant unless we have requirements
-        - destroy
-        - syntax
-        - create
-#        - prepare
-        - converge
-        - idempotence
-        #- verify
-        - cleanup
-        - destroy
+  name: system_access_users
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - cleanup
+    - destroy
 
-driver:
-    name: vagrant
-    parallel: true
+ansible:
+  playbooks:
+    create: ../_resources/create.yml
+    destroy: ../_resources/destroy.yml
+  executor:
+    backend: ansible-playbook
+    args:
+      ansible_playbook:
+        - --inventory=${MOLECULE_PROJECT_DIRECTORY}/molecule/_inventory/
 
-platforms:
-    - name: "24.7"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "24.7"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-        - 'vm.guest = :freebsd'
-        - 'ssh.sudo_command = "%c"'
-        - 'ssh.shell = "/bin/sh"'
-
-provisioner:
-    name: ansible
-    env:
-        ANSIBLE_LIBRARY: "${VIRTUAL_ENV}/lib/python3.11/site-packages/molecule_plugins/vagrant/modules"
 verifier:
-    name: ansible
-    options:
-        become: true
+  name: ansible
+  options:
+    become: true

--- a/molecule/system_access_users/verify.yml
+++ b/molecule/system_access_users/verify.yml
@@ -1,6 +1,6 @@
 ---
 - name: Verify connectivity to server
-  hosts: all
+  hosts: system_access_users
   tasks:
     - name: Ping the server
       ansible.builtin.ping:

--- a/molecule/system_high_availability_settings/converge.yml
+++ b/molecule/system_high_availability_settings/converge.yml
@@ -1,6 +1,6 @@
 ---
 - name: Converge
-  hosts: all
+  hosts: system_high_availability_settings
   become: true
   vars:
     services:

--- a/molecule/system_high_availability_settings/molecule.yml
+++ b/molecule/system_high_availability_settings/molecule.yml
@@ -1,47 +1,25 @@
 ---
 scenario:
-    name: system_high_availability_settings
-    test_sequence:
-        # - dependency not relevant uless we have requirements
-        - destroy
-        - syntax
-        - create
-        - converge
-        - verify
-        - destroy
+  name: system_high_availability_settings
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - converge
+    - verify
+    - destroy
 
-driver:
-    name: vagrant
-    parallel: true
+ansible:
+  playbooks:
+    create: ../_resources/create.yml
+    destroy: ../_resources/destroy.yml
+  executor:
+    backend: ansible-playbook
+    args:
+      ansible_playbook:
+        - --inventory=${MOLECULE_PROJECT_DIRECTORY}/molecule/_inventory/
 
-platforms:
-    - name: "24.7"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "24.7"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-          - 'vm.guest = :freebsd'
-          - 'ssh.sudo_command = "%c"'
-          - 'ssh.shell = "/bin/sh"'
-
-    - name: "25.1"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "25.1"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-          - 'vm.guest = :freebsd'
-          - 'ssh.sudo_command = "%c"'
-          - 'ssh.shell = "/bin/sh"'
-
-provisioner:
-    name: ansible
-    env:
-        ANSIBLE_LIBRARY: "${VIRTUAL_ENV}/lib/python3.11/site-packages/molecule_plugins/vagrant/modules"
 verifier:
-    name: ansible
-    options:
-        become: true
+  name: ansible
+  options:
+    become: true

--- a/molecule/system_high_availability_settings/verify.yml
+++ b/molecule/system_high_availability_settings/verify.yml
@@ -1,6 +1,6 @@
 ---
 - name: Verify connectivity to server
-  hosts: all
+  hosts: system_high_availability_settings
   tasks:
     - name: Ping the server
       ansible.builtin.ping:

--- a/molecule/system_settings_general/converge.yml
+++ b/molecule/system_settings_general/converge.yml
@@ -1,6 +1,6 @@
 ---
 - name: converge
-  hosts: all
+  hosts: system_settings_general
   become: true
   tasks:
     - name: Converge - Set hostname

--- a/molecule/system_settings_general/molecule.yml
+++ b/molecule/system_settings_general/molecule.yml
@@ -1,67 +1,26 @@
 ---
 scenario:
-    name: system_settings_general
-    test_sequence:
-        # - dependency not relevant unless we have requirements
-        - destroy
-        - syntax
-        - create
-        - converge
-        - idempotence
-        - verify
-        - destroy
+  name: system_settings_general
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - verify
+    - destroy
 
-driver:
-    name: vagrant
-    parallel: true
+ansible:
+  playbooks:
+    create: ../_resources/create.yml
+    destroy: ../_resources/destroy.yml
+  executor:
+    backend: ansible-playbook
+    args:
+      ansible_playbook:
+        - --inventory=${MOLECULE_PROJECT_DIRECTORY}/molecule/_inventory/
 
-platforms:
-    - name: "24.7"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "24.7"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-        - 'vm.guest = :freebsd'
-        - 'ssh.sudo_command = "%c"'
-        - 'ssh.shell = "/bin/sh"'
-    - name: "25.1"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "25.1"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-        - 'vm.guest = :freebsd'
-        - 'ssh.sudo_command = "%c"'
-        - 'ssh.shell = "/bin/sh"'
-    - name: "25.7"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "25.7"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-        - 'vm.guest = :freebsd'
-        - 'ssh.sudo_command = "%c"'
-        - 'ssh.shell = "/bin/sh"'
-    - name: "26.1"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "26.1"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-        - 'vm.guest = :freebsd'
-        - 'ssh.sudo_command = "%c"'
-        - 'ssh.shell = "/bin/sh"'
-
-provisioner:
-    name: ansible
-    env:
-        ANSIBLE_LIBRARY: "${VIRTUAL_ENV}/lib/python3.11/site-packages/molecule_plugins/vagrant/modules"
 verifier:
-    name: ansible
-    options:
-        become: true
+  name: ansible
+  options:
+    become: true

--- a/molecule/system_settings_general/verify.yml
+++ b/molecule/system_settings_general/verify.yml
@@ -1,6 +1,6 @@
 ---
 - name: Verify connectivity to server
-  hosts: all
+  hosts: system_settings_general
   tasks:
     - name: Ping the server
       ansible.builtin.ping:

--- a/molecule/system_settings_logging/converge.yml
+++ b/molecule/system_settings_logging/converge.yml
@@ -1,6 +1,6 @@
 ---
 - name: converge
-  hosts: all
+  hosts: system_settings_logging
   become: true
   tasks:
 

--- a/molecule/system_settings_logging/molecule.yml
+++ b/molecule/system_settings_logging/molecule.yml
@@ -1,36 +1,26 @@
 ---
 scenario:
-    name: system_settings_logging
-    test_sequence:
-        # - dependency not relevant unless we have requirements
-        - destroy
-        - syntax
-        - create
-        - converge
-        - idempotence
-        - verify
-        - destroy
+  name: system_settings_logging
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - verify
+    - destroy
 
-driver:
-    name: vagrant
-    parallel: true
+ansible:
+  playbooks:
+    create: ../_resources/create.yml
+    destroy: ../_resources/destroy.yml
+  executor:
+    backend: ansible-playbook
+    args:
+      ansible_playbook:
+        - --inventory=${MOLECULE_PROJECT_DIRECTORY}/molecule/_inventory/
 
-platforms:
-    - name: "24.7"
-      box: puzzle/opnsense
-      hostname: false
-      box_version: "24.7"
-      memory: 1024
-      cpus: 2
-      instance_raw_config_args:
-        - 'vm.guest = :freebsd'
-        - 'ssh.sudo_command = "%c"'
-        - 'ssh.shell = "/bin/sh"'
-provisioner:
-    name: ansible
-    env:
-        ANSIBLE_LIBRARY: "${VIRTUAL_ENV}/lib/python3.11/site-packages/molecule_plugins/vagrant/modules"
 verifier:
-    name: ansible
-    options:
-        become: true
+  name: ansible
+  options:
+    become: true

--- a/molecule/system_settings_logging/verify.yml
+++ b/molecule/system_settings_logging/verify.yml
@@ -1,6 +1,6 @@
 ---
 - name: Verify connectivity to server
-  hosts: all
+  hosts: system_settings_logging
   tasks:
     - name: Ping the server
       ansible.builtin.ping:

--- a/plugins/module_utils/system_access_users_utils.py
+++ b/plugins/module_utils/system_access_users_utils.py
@@ -311,13 +311,11 @@ class User:
             return hashed_secret_value.get("stdout")
 
         # if validation fails,
-        raise OPNsenseCryptReturnError(
-            f"""
+        raise OPNsenseCryptReturnError(f"""
             validation of the secret failed!
             Secret must start with $6$ and have a min length of 90
             Value: {hashed_secret_value}
-            """
-        )
+            """)
 
     def __init__(self, **kwargs):
         # set default attributes


### PR DESCRIPTION
## **Problem**

The molecule test setup relied on `molecule-plugins` (vagrant driver) which is effectively unmaintained and blocks adoption of current Python and Ansible versions. Each scenario also duplicated the full Vagrant platform definition, making it painful to add a new OPNsense version.

## **Solution**

Migrate all scenarios to Molecule's ansible-native idiom using custom `create`/`destroy` playbooks:

- Drop `molecule-plugins` from `Pipfile`
- Add `molecule/_inventory/hosts.ini` — a single shared inventory that groups hosts by scenario name; adding a new OPNsense version now requires touching one file
- Add `molecule/_resources/{create,destroy,preconfig}.yml` and a `Vagrantfile.j2` template — shared across all scenarios, no more per-scenario driver boilerplate
- Simplify all `molecule.yml` files: replace `driver`/`platforms`/`provisioner` blocks with an `ansible:` block pointing at the shared resources
- Target scenario-specific inventory groups in `converge.yml`/`verify.yml` (`hosts: all` → `hosts: <scenario_name>`) to avoid cross-contamination when the shared inventory is loaded

## **Benefits**
- Unblocks Python 3.12+/ansible-core 2.18+ compatibility
- Platform list is centralized — one line in `hosts.ini` to add a version
- ~200 fewer lines across molecule configs